### PR TITLE
Check if the persistent_id key is set in the RedisResource Manager

### DIFF
--- a/src/Storage/Adapter/RedisResourceManager.php
+++ b/src/Storage/Adapter/RedisResourceManager.php
@@ -262,7 +262,7 @@ class RedisResourceManager
     {
         $server = $resource['server'];
         $redis  = $resource['resource'];
-        if ($resource['persistent_id'] !== '') {
+        if (isset($resource['persistent_id']) && $resource['persistent_id'] !== '') {
             //connect or reuse persistent connection
             $success = $redis->pconnect($server['host'], $server['port'], $server['timeout'], $server['persistent_id']);
         } elseif ($server['port']) {

--- a/test/Storage/Adapter/RedisResourceManagerTest.php
+++ b/test/Storage/Adapter/RedisResourceManagerTest.php
@@ -9,6 +9,8 @@
 
 namespace ZendTest\Cache\Storage\Adapter;
 
+use Zend\Cache\Storage\Adapter\Redis;
+use Zend\Cache\Storage\Adapter\RedisOptions;
 use Zend\Cache\Storage\Adapter\RedisResourceManager;
 
 /**
@@ -130,5 +132,24 @@ class RedisResourceManagerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNotSame($expectedPersistentId, $this->resourceManager->getPersistentId($resourceId));
         $this->assertEmpty($this->resourceManager->getPersistentId($resourceId));
+    }
+
+    /**
+     * @group 2
+     */
+    public function testConnectUsesPersistentIdSetViaOptions()
+    {
+        if (! extension_loaded('redis')) {
+            $this->markTestSkipped('This test requires the redis extension');
+        }
+
+        $options = new RedisOptions();
+        $options
+            ->setServer([ 'host' => 'localhost' ])
+            ->setPersistentId('RDB');
+
+        // This essentially succeeds if no notices are issued.
+        $redis = new Redis($options);
+        $this->assertInstanceOf('Zend\Cache\Storage\Adapter\Redis', $redis);
     }
 }


### PR DESCRIPTION
I'm trying to create a RedisFactory and I start with a simple
```

$redisOptions = new RedisOptions();
$redisOptions
    ->setServer($redisServer)
    ->setNamespace('Uala_Redis')
    ->setPersistentId('RDB')
    ->setTtl(3600);

$redisOptions->setLibOptions([
    \Redis::OPT_SERIALIZER => \Redis::SERIALIZER_PHP
]);

$redis = new Redis($redisOptions);
```

However, when it's initialized I receive this warning:
```
( ! ) Notice: Undefined index: persistent_id in /Users/Oscar/Sites/uala/vendor/zendframework/zendframework/library/Zend/Cache/Storage/Adapter/RedisResourceManager.php on line 267
```

Someone know why?

I'm using redis-server `v3.0.2` and php-redis `v2.2.7`

Thanks