### PR TITLE
Set ttl to specific cache key for Redis Storage Adapter

### DIFF
--- a/src/Storage/Adapter/Redis.php
+++ b/src/Storage/Adapter/Redis.php
@@ -175,7 +175,7 @@ class Redis extends AbstractAdapter implements
     {
         $redis = $this->getRedisResource();
 
-        $namespacedKeys = [];
+        $namespacedKeys = array();
         foreach ($normalizedKeys as $normalizedKey) {
             $namespacedKeys[] = $this->namespacePrefix . $normalizedKey;
         }
@@ -255,7 +255,7 @@ class Redis extends AbstractAdapter implements
         $redis = $this->getRedisResource();
         $ttl   = $this->getOptions()->getTtl();
 
-        $namespacedKeyValuePairs = [];
+        $namespacedKeyValuePairs = array();
         foreach ($normalizedKeyValuePairs as $normalizedKey => $value) {
             $namespacedKeyValuePairs[$this->namespacePrefix . $normalizedKey] = $value;
         }
@@ -281,7 +281,7 @@ class Redis extends AbstractAdapter implements
             throw new Exception\RuntimeException($redis->getLastError());
         }
 
-        return [];
+        return array();
     }
 
     /**
@@ -434,8 +434,8 @@ class Redis extends AbstractAdapter implements
             $this->capabilities     = new Capabilities(
                 $this,
                 $this->capabilityMarker,
-                [
-                    'supportedDatatypes' => [
+                array(
+                    'supportedDatatypes' => array(
                         'NULL'     => 'string',
                         'boolean'  => 'string',
                         'integer'  => 'string',
@@ -444,8 +444,8 @@ class Redis extends AbstractAdapter implements
                         'array'    => false,
                         'object'   => false,
                         'resource' => false,
-                    ],
-                    'supportedMetadata'  => [],
+                    ),
+                    'supportedMetadata'  => array(),
                     'minTtl'             => $minTtl,
                     'maxTtl'             => 0,
                     'staticTtl'          => true,
@@ -454,7 +454,7 @@ class Redis extends AbstractAdapter implements
                     'expiredRead'        => false,
                     'maxKeyLength'       => 255,
                     'namespaceIsPrefix'  => true,
-                ]
+                )
             );
         }
 
@@ -468,6 +468,7 @@ class Redis extends AbstractAdapter implements
      * @param integer $ttl
      *
      * @return bool
+     * @throws Exception\RuntimeException
      */
     public function setTimeout($key, $ttl)
     {
@@ -489,6 +490,7 @@ class Redis extends AbstractAdapter implements
      * @param string $key
      *
      * @return int
+     * @throws Exception\RuntimeException
      */
     public function getRemainingTimeout($key)
     {

--- a/src/Storage/Adapter/RedisResourceManager.php
+++ b/src/Storage/Adapter/RedisResourceManager.php
@@ -264,7 +264,7 @@ class RedisResourceManager
         $redis  = $resource['resource'];
         if ($resource['persistent_id'] !== '') {
             //connect or reuse persistent connection
-            $success = $redis->pconnect($server['host'], $server['port'], $server['timeout'], $server['persistent_id']);
+            $success = $redis->pconnect($server['host'], $server['port'], $server['timeout'], $resource['persistent_id']);
         } elseif ($server['port']) {
             $success = $redis->connect($server['host'], $server['port'], $server['timeout']);
         } elseif ($server['timeout']) {

--- a/src/Storage/Adapter/RedisResourceManager.php
+++ b/src/Storage/Adapter/RedisResourceManager.php
@@ -264,7 +264,7 @@ class RedisResourceManager
         $redis  = $resource['resource'];
         if ($resource['persistent_id'] !== '') {
             //connect or reuse persistent connection
-            $success = $redis->pconnect($server['host'], $server['port'], $server['timeout'], $resource['persistent_id']);
+            $success = $redis->pconnect($server['host'], $server['port'], $server['timeout'], $server['persistent_id']);
         } elseif ($server['port']) {
             $success = $redis->connect($server['host'], $server['port'], $server['timeout']);
         } elseif ($server['timeout']) {

--- a/src/Storage/ExpirableInterface.php
+++ b/src/Storage/ExpirableInterface.php
@@ -9,6 +9,13 @@
 
 namespace Zend\Cache\Storage;
 
+/**
+ * Interface ExpirableInterface
+ * Adapters that implements this interfaces are able to set a specific ttl to their items
+ *  and get the remaining ttl applied to their items
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ */
 interface ExpirableInterface
 {
     /**

--- a/src/Storage/ExpirableInterface.php
+++ b/src/Storage/ExpirableInterface.php
@@ -9,32 +9,35 @@
 
 namespace Zend\Cache\Storage;
 
+use Zend\Cache\Exception;
+
 /**
  * Interface ExpirableInterface
  * Adapters that implements this interfaces are able to set a specific ttl to their items
  *  and get the remaining ttl applied to their items
  *
- * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ * @author Oscar Fanelli <oscar.nesis@gmail.com>
  */
 interface ExpirableInterface
 {
     /**
      * Sets an expiration date (a timeout) on an item
      *
-     * @param $key
-     * @param $ttl
+     * @param string $key
+     * @param int $ttl
      *
      * @return bool
+     * @throws Exception\RuntimeException
      */
     public function setTimeout($key, $ttl);
 
     /**
      * Remaining timeout of an item
      *
-     * @param $key
+     * @param string $key
      *
-     * @return mixed
+     * @return int
+     * @throws Exception\RuntimeException
      */
     public function getRemainingTimeout($key);
-
 }

--- a/src/Storage/ExpirableInterface.php
+++ b/src/Storage/ExpirableInterface.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\Cache\Storage;
+
+interface ExpirableInterface
+{
+    /**
+     * Sets an expiration date (a timeout) on an item
+     *
+     * @param $key
+     * @param $ttl
+     *
+     * @return bool
+     */
+    public function setTimeout($key, $ttl);
+
+    /**
+     * Remaining timeout of an item
+     *
+     * @param $key
+     *
+     * @return mixed
+     */
+    public function getRemainingTimeout($key);
+
+}

--- a/test/Storage/Adapter/RedisTest.php
+++ b/test/Storage/Adapter/RedisTest.php
@@ -312,4 +312,21 @@ class RedisTest extends CommonAdapterTest
         $this->_options->setPassword($password);
         $this->assertEquals($password, $this->_options->getPassword(), 'Password was set incorrectly using RedisOptions');
     }
+
+    public function testSetTimeout()
+    {
+        $ttl = 300;
+        $key = 'key';
+        $this->_storage->setItem($key, 'val');
+        $this->assertTrue($this->_storage->setTimeout($key, $ttl));
+    }
+
+    public function testGetRemainingTimeout()
+    {
+        $ttl = 300;
+        $key = 'key';
+        $this->_storage->setItem($key, 'val');
+        $this->_storage->setTimeout($key, $ttl);
+        $this->assertEquals($ttl, $this->_storage->getRemainingTimeout($key));
+    }
 }


### PR DESCRIPTION
Implemented two methods inside the `Storage\Adapter\Redis` that allow to:
- set a ttl to a specific key after setting it up (`setTimeout`)
- get the remaining tll of a specific key (`getRemainingTimeout`)

Actually is possible to specify a ttl to the adapter, but it will be assumed by all the keys that are setted up after the initialization.
Tests and interface implemented.