### PR TITLE
reduce arguments by reference

### DIFF
--- a/src/Storage/Adapter/AbstractAdapter.php
+++ b/src/Storage/Adapter/AbstractAdapter.php
@@ -340,7 +340,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
             return;
         }
 
-        $this->normalizeKey($key);
+        $key  = $this->normalizeKey($key);
 
         $argn = func_num_args();
         $args = [
@@ -403,7 +403,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
             return [];
         }
 
-        $this->normalizeKeys($keys);
+        $keys = $this->normalizeKeys($keys);
         $args = new ArrayObject([
             'keys' => & $keys,
         ]);
@@ -460,7 +460,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
             return false;
         }
 
-        $this->normalizeKey($key);
+        $key  = $this->normalizeKey($key);
         $args = new ArrayObject([
             'key' => & $key,
         ]);
@@ -510,7 +510,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
             return [];
         }
 
-        $this->normalizeKeys($keys);
+        $keys = $this->normalizeKeys($keys);
         $args = new ArrayObject([
             'keys' => & $keys,
         ]);
@@ -564,7 +564,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
             return false;
         }
 
-        $this->normalizeKey($key);
+        $key  = $this->normalizeKey($key);
         $args = new ArrayObject([
             'key' => & $key,
         ]);
@@ -616,7 +616,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
             return [];
         }
 
-        $this->normalizeKeys($keys);
+        $keys = $this->normalizeKeys($keys);
         $args = new ArrayObject([
             'keys' => & $keys,
         ]);
@@ -674,7 +674,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
             return false;
         }
 
-        $this->normalizeKey($key);
+        $key  = $this->normalizeKey($key);
         $args = new ArrayObject([
             'key'   => & $key,
             'value' => & $value,
@@ -721,8 +721,8 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
             return array_keys($keyValuePairs);
         }
 
-        $this->normalizeKeyValuePairs($keyValuePairs);
-        $args = new ArrayObject([
+        $keyValuePairs = $this->normalizeKeyValuePairs($keyValuePairs);
+        $args          = new ArrayObject([
             'keyValuePairs' => & $keyValuePairs,
         ]);
 
@@ -776,7 +776,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
             return false;
         }
 
-        $this->normalizeKey($key);
+        $key  = $this->normalizeKey($key);
         $args = new ArrayObject([
             'key'   => & $key,
             'value' => & $value,
@@ -829,8 +829,8 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
             return array_keys($keyValuePairs);
         }
 
-        $this->normalizeKeyValuePairs($keyValuePairs);
-        $args = new ArrayObject([
+        $keyValuePairs = $this->normalizeKeyValuePairs($keyValuePairs);
+        $args          = new ArrayObject([
             'keyValuePairs' => & $keyValuePairs,
         ]);
 
@@ -884,7 +884,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
             return false;
         }
 
-        $this->normalizeKey($key);
+        $key  = $this->normalizeKey($key);
         $args = new ArrayObject([
             'key'   => & $key,
             'value' => & $value,
@@ -938,8 +938,8 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
             return array_keys($keyValuePairs);
         }
 
-        $this->normalizeKeyValuePairs($keyValuePairs);
-        $args = new ArrayObject([
+        $keyValuePairs = $this->normalizeKeyValuePairs($keyValuePairs);
+        $args          = new ArrayObject([
             'keyValuePairs' => & $keyValuePairs,
         ]);
 
@@ -995,7 +995,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
             return false;
         }
 
-        $this->normalizeKey($key);
+        $key  = $this->normalizeKey($key);
         $args = new ArrayObject([
             'token' => & $token,
             'key'   => & $key,
@@ -1054,7 +1054,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
             return false;
         }
 
-        $this->normalizeKey($key);
+        $key  = $this->normalizeKey($key);
         $args = new ArrayObject([
             'key' => & $key,
         ]);
@@ -1108,7 +1108,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
             return $keys;
         }
 
-        $this->normalizeKeys($keys);
+        $keys = $this->normalizeKeys($keys);
         $args = new ArrayObject([
             'keys' => & $keys,
         ]);
@@ -1161,7 +1161,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
             return false;
         }
 
-        $this->normalizeKey($key);
+        $key  = $this->normalizeKey($key);
         $args = new ArrayObject([
             'key' => & $key,
         ]);
@@ -1206,7 +1206,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
             return $keys;
         }
 
-        $this->normalizeKeys($keys);
+        $keys = $this->normalizeKeys($keys);
         $args = new ArrayObject([
             'keys' => & $keys,
         ]);
@@ -1260,7 +1260,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
             return false;
         }
 
-        $this->normalizeKey($key);
+        $key  = $this->normalizeKey($key);
         $args = new ArrayObject([
             'key'   => & $key,
             'value' => & $value,
@@ -1321,8 +1321,8 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
             return [];
         }
 
-        $this->normalizeKeyValuePairs($keyValuePairs);
-        $args = new ArrayObject([
+        $keyValuePairs = $this->normalizeKeyValuePairs($keyValuePairs);
+        $args          = new ArrayObject([
             'keyValuePairs' => & $keyValuePairs,
         ]);
 
@@ -1377,7 +1377,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
             return false;
         }
 
-        $this->normalizeKey($key);
+        $key  = $this->normalizeKey($key);
         $args = new ArrayObject([
             'key'   => & $key,
             'value' => & $value,
@@ -1438,8 +1438,8 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
             return [];
         }
 
-        $this->normalizeKeyValuePairs($keyValuePairs);
-        $args = new ArrayObject([
+        $keyValuePairs = $this->normalizeKeyValuePairs($keyValuePairs);
+        $args          = new ArrayObject([
             'keyValuePairs' => & $keyValuePairs,
         ]);
 
@@ -1527,7 +1527,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @return void
      * @throws Exception\InvalidArgumentException On an invalid key
      */
-    protected function normalizeKey(& $key)
+    protected function normalizeKey($key)
     {
         $key = (string) $key;
 
@@ -1540,6 +1540,8 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
                 "The key '{$key}' doesn't match against pattern '{$p}'"
             );
         }
+
+        return $key;
     }
 
     /**
@@ -1549,7 +1551,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @return void
      * @throws Exception\InvalidArgumentException On an invalid key
      */
-    protected function normalizeKeys(array & $keys)
+    protected function normalizeKeys(array $keys)
     {
         if (!$keys) {
             throw new Exception\InvalidArgumentException(
@@ -1557,8 +1559,9 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
             );
         }
 
-        array_walk($keys, [$this, 'normalizeKey']);
+        $keys = array_map([$this, 'normalizeKey'], $keys);
         $keys = array_values(array_unique($keys));
+        return $keys;
     }
 
     /**
@@ -1568,13 +1571,13 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @return void
      * @throws Exception\InvalidArgumentException On an invalid key
      */
-    protected function normalizeKeyValuePairs(array & $keyValuePairs)
+    protected function normalizeKeyValuePairs(array $keyValuePairs)
     {
         $normalizedKeyValuePairs = [];
         foreach ($keyValuePairs as $key => $value) {
             $this->normalizeKey($key);
             $normalizedKeyValuePairs[$key] = $value;
         }
-        $keyValuePairs = $normalizedKeyValuePairs;
+        return $normalizedKeyValuePairs;
     }
 }

--- a/src/Storage/Adapter/AbstractAdapter.php
+++ b/src/Storage/Adapter/AbstractAdapter.php
@@ -1524,7 +1524,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * Validates and normalizes a key
      *
      * @param  string $key
-     * @return void
+     * @return string
      * @throws Exception\InvalidArgumentException On an invalid key
      */
     protected function normalizeKey($key)
@@ -1547,8 +1547,8 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
     /**
      * Validates and normalizes multiple keys
      *
-     * @param  array $keys
-     * @return void
+     * @param  string[] $keys
+     * @return string[]
      * @throws Exception\InvalidArgumentException On an invalid key
      */
     protected function normalizeKeys(array $keys)
@@ -1568,7 +1568,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * Validates and normalizes an array of key-value pairs
      *
      * @param  array $keyValuePairs
-     * @return void
+     * @return array
      * @throws Exception\InvalidArgumentException On an invalid key
      */
     protected function normalizeKeyValuePairs(array $keyValuePairs)

--- a/src/Storage/Adapter/AbstractAdapter.php
+++ b/src/Storage/Adapter/AbstractAdapter.php
@@ -215,7 +215,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @param  mixed       $result
      * @return mixed
      */
-    protected function triggerPost($eventName, ArrayObject $args, & $result)
+    protected function triggerPost($eventName, ArrayObject $args, $result)
     {
         $postEvent = new PostEvent($eventName . '.post', $this, $args, $result);
         $eventRs   = $this->getEventManager()->triggerEvent($postEvent);
@@ -238,7 +238,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @throws Exception\ExceptionInterface
      * @return mixed
      */
-    protected function triggerException($eventName, ArrayObject $args, & $result, \Exception $exception)
+    protected function triggerException($eventName, ArrayObject $args, $result, \Exception $exception)
     {
         $exceptionEvent = new ExceptionEvent($eventName . '.exception', $this, $args, $result, $exception);
         $eventRs        = $this->getEventManager()->triggerEvent($exceptionEvent);
@@ -344,7 +344,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
 
         $argn = func_num_args();
         $args = [
-            'key' => & $key,
+            'key' => $key,
         ];
         if ($argn > 1) {
             $args['success'] = & $success;
@@ -405,7 +405,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
 
         $keys = $this->normalizeKeys($keys);
         $args = new ArrayObject([
-            'keys' => & $keys,
+            'keys' => $keys,
         ]);
 
         try {
@@ -462,7 +462,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
 
         $key  = $this->normalizeKey($key);
         $args = new ArrayObject([
-            'key' => & $key,
+            'key' => $key,
         ]);
 
         try {
@@ -512,7 +512,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
 
         $keys = $this->normalizeKeys($keys);
         $args = new ArrayObject([
-            'keys' => & $keys,
+            'keys' => $keys,
         ]);
 
         try {
@@ -566,7 +566,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
 
         $key  = $this->normalizeKey($key);
         $args = new ArrayObject([
-            'key' => & $key,
+            'key' => $key,
         ]);
 
         try {
@@ -618,7 +618,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
 
         $keys = $this->normalizeKeys($keys);
         $args = new ArrayObject([
-            'keys' => & $keys,
+            'keys' => $keys,
         ]);
 
         try {
@@ -676,8 +676,8 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
 
         $key  = $this->normalizeKey($key);
         $args = new ArrayObject([
-            'key'   => & $key,
-            'value' => & $value,
+            'key'   => $key,
+            'value' => $value,
         ]);
 
         try {
@@ -723,7 +723,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
 
         $keyValuePairs = $this->normalizeKeyValuePairs($keyValuePairs);
         $args          = new ArrayObject([
-            'keyValuePairs' => & $keyValuePairs,
+            'keyValuePairs' => $keyValuePairs,
         ]);
 
         try {
@@ -778,8 +778,8 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
 
         $key  = $this->normalizeKey($key);
         $args = new ArrayObject([
-            'key'   => & $key,
-            'value' => & $value,
+            'key'   => $key,
+            'value' => $value,
         ]);
 
         try {
@@ -831,7 +831,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
 
         $keyValuePairs = $this->normalizeKeyValuePairs($keyValuePairs);
         $args          = new ArrayObject([
-            'keyValuePairs' => & $keyValuePairs,
+            'keyValuePairs' => $keyValuePairs,
         ]);
 
         try {
@@ -886,8 +886,8 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
 
         $key  = $this->normalizeKey($key);
         $args = new ArrayObject([
-            'key'   => & $key,
-            'value' => & $value,
+            'key'   => $key,
+            'value' => $value,
         ]);
 
         try {
@@ -940,7 +940,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
 
         $keyValuePairs = $this->normalizeKeyValuePairs($keyValuePairs);
         $args          = new ArrayObject([
-            'keyValuePairs' => & $keyValuePairs,
+            'keyValuePairs' => $keyValuePairs,
         ]);
 
         try {
@@ -997,9 +997,9 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
 
         $key  = $this->normalizeKey($key);
         $args = new ArrayObject([
-            'token' => & $token,
-            'key'   => & $key,
-            'value' => & $value,
+            'token' => $token,
+            'key'   => $key,
+            'value' => $value,
         ]);
 
         try {
@@ -1056,7 +1056,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
 
         $key  = $this->normalizeKey($key);
         $args = new ArrayObject([
-            'key' => & $key,
+            'key' => $key,
         ]);
 
         try {
@@ -1110,7 +1110,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
 
         $keys = $this->normalizeKeys($keys);
         $args = new ArrayObject([
-            'keys' => & $keys,
+            'keys' => $keys,
         ]);
 
         try {
@@ -1163,7 +1163,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
 
         $key  = $this->normalizeKey($key);
         $args = new ArrayObject([
-            'key' => & $key,
+            'key' => $key,
         ]);
 
         try {
@@ -1208,7 +1208,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
 
         $keys = $this->normalizeKeys($keys);
         $args = new ArrayObject([
-            'keys' => & $keys,
+            'keys' => $keys,
         ]);
 
         try {
@@ -1262,8 +1262,8 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
 
         $key  = $this->normalizeKey($key);
         $args = new ArrayObject([
-            'key'   => & $key,
-            'value' => & $value,
+            'key'   => $key,
+            'value' => $value,
         ]);
 
         try {
@@ -1323,7 +1323,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
 
         $keyValuePairs = $this->normalizeKeyValuePairs($keyValuePairs);
         $args          = new ArrayObject([
-            'keyValuePairs' => & $keyValuePairs,
+            'keyValuePairs' => $keyValuePairs,
         ]);
 
         try {
@@ -1379,8 +1379,8 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
 
         $key  = $this->normalizeKey($key);
         $args = new ArrayObject([
-            'key'   => & $key,
-            'value' => & $value,
+            'key'   => $key,
+            'value' => $value,
         ]);
 
         try {
@@ -1440,7 +1440,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
 
         $keyValuePairs = $this->normalizeKeyValuePairs($keyValuePairs);
         $args          = new ArrayObject([
-            'keyValuePairs' => & $keyValuePairs,
+            'keyValuePairs' => $keyValuePairs,
         ]);
 
         try {

--- a/src/Storage/Adapter/AbstractAdapter.php
+++ b/src/Storage/Adapter/AbstractAdapter.php
@@ -384,7 +384,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @return mixed Data on success, null on failure
      * @throws Exception\ExceptionInterface
      */
-    abstract protected function internalGetItem(& $normalizedKey, & $success = null, & $casToken = null);
+    abstract protected function internalGetItem($normalizedKey, & $success = null, & $casToken = null);
 
     /**
      * Get multiple items.
@@ -429,7 +429,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @return array Associative array of keys and values
      * @throws Exception\ExceptionInterface
      */
-    protected function internalGetItems(array & $normalizedKeys)
+    protected function internalGetItems(array $normalizedKeys)
     {
         $success = null;
         $result  = [];
@@ -486,7 +486,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalHasItem(& $normalizedKey)
+    protected function internalHasItem($normalizedKey)
     {
         $success = null;
         $this->internalGetItem($normalizedKey, $success);
@@ -536,7 +536,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @return array Array of found keys
      * @throws Exception\ExceptionInterface
      */
-    protected function internalHasItems(array & $normalizedKeys)
+    protected function internalHasItems(array $normalizedKeys)
     {
         $result = [];
         foreach ($normalizedKeys as $normalizedKey) {
@@ -590,7 +590,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @return array|bool Metadata on success, false on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalGetMetadata(& $normalizedKey)
+    protected function internalGetMetadata($normalizedKey)
     {
         if (!$this->internalHasItem($normalizedKey)) {
             return false;
@@ -642,7 +642,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @return array Associative array of keys and metadata
      * @throws Exception\ExceptionInterface
      */
-    protected function internalGetMetadatas(array & $normalizedKeys)
+    protected function internalGetMetadatas(array $normalizedKeys)
     {
         $result = [];
         foreach ($normalizedKeys as $normalizedKey) {
@@ -702,7 +702,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    abstract protected function internalSetItem(& $normalizedKey, & $value);
+    abstract protected function internalSetItem($normalizedKey, $value);
 
     /**
      * Store multiple items.
@@ -747,7 +747,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @return array Array of not stored keys
      * @throws Exception\ExceptionInterface
      */
-    protected function internalSetItems(array & $normalizedKeyValuePairs)
+    protected function internalSetItems(array $normalizedKeyValuePairs)
     {
         $failedKeys = [];
         foreach ($normalizedKeyValuePairs as $normalizedKey => $value) {
@@ -804,7 +804,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalAddItem(& $normalizedKey, & $value)
+    protected function internalAddItem($normalizedKey, $value)
     {
         if ($this->internalHasItem($normalizedKey)) {
             return false;
@@ -855,7 +855,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @return array Array of not stored keys
      * @throws Exception\ExceptionInterface
      */
-    protected function internalAddItems(array & $normalizedKeyValuePairs)
+    protected function internalAddItems(array $normalizedKeyValuePairs)
     {
         $result = [];
         foreach ($normalizedKeyValuePairs as $normalizedKey => $value) {
@@ -912,7 +912,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalReplaceItem(& $normalizedKey, & $value)
+    protected function internalReplaceItem($normalizedKey, $value)
     {
         if (!$this->internalhasItem($normalizedKey)) {
             return false;
@@ -964,7 +964,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @return array Array of not stored keys
      * @throws Exception\ExceptionInterface
      */
-    protected function internalReplaceItems(array & $normalizedKeyValuePairs)
+    protected function internalReplaceItems(array $normalizedKeyValuePairs)
     {
         $result = [];
         foreach ($normalizedKeyValuePairs as $normalizedKey => $value) {
@@ -1027,7 +1027,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @see    getItem()
      * @see    setItem()
      */
-    protected function internalCheckAndSetItem(& $token, & $normalizedKey, & $value)
+    protected function internalCheckAndSetItem($token, $normalizedKey, $value)
     {
         $oldValue = $this->internalGetItem($normalizedKey);
         if ($oldValue !== $token) {
@@ -1080,7 +1080,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalTouchItem(& $normalizedKey)
+    protected function internalTouchItem($normalizedKey)
     {
         $success = null;
         $value   = $this->internalGetItem($normalizedKey, $success);
@@ -1133,7 +1133,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @return array Array of not updated keys
      * @throws Exception\ExceptionInterface
      */
-    protected function internalTouchItems(array & $normalizedKeys)
+    protected function internalTouchItems(array $normalizedKeys)
     {
         $result = [];
         foreach ($normalizedKeys as $normalizedKey) {
@@ -1187,7 +1187,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    abstract protected function internalRemoveItem(& $normalizedKey);
+    abstract protected function internalRemoveItem($normalizedKey);
 
     /**
      * Remove multiple items.
@@ -1231,7 +1231,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @return array Array of not removed keys
      * @throws Exception\ExceptionInterface
      */
-    protected function internalRemoveItems(array & $normalizedKeys)
+    protected function internalRemoveItems(array $normalizedKeys)
     {
         $result = [];
         foreach ($normalizedKeys as $normalizedKey) {
@@ -1288,7 +1288,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @return int|bool The new value on success, false on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalIncrementItem(& $normalizedKey, & $value)
+    protected function internalIncrementItem($normalizedKey, $value)
     {
         $success  = null;
         $value    = (int) $value;
@@ -1347,7 +1347,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @return array Associative array of keys and new values
      * @throws Exception\ExceptionInterface
      */
-    protected function internalIncrementItems(array & $normalizedKeyValuePairs)
+    protected function internalIncrementItems(array $normalizedKeyValuePairs)
     {
         $result = [];
         foreach ($normalizedKeyValuePairs as $normalizedKey => $value) {
@@ -1405,7 +1405,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @return int|bool The new value on success, false on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalDecrementItem(& $normalizedKey, & $value)
+    protected function internalDecrementItem($normalizedKey, $value)
     {
         $success  = null;
         $value    = (int) $value;
@@ -1464,7 +1464,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @return array Associative array of keys and new values
      * @throws Exception\ExceptionInterface
      */
-    protected function internalDecrementItems(array & $normalizedKeyValuePairs)
+    protected function internalDecrementItems(array $normalizedKeyValuePairs)
     {
         $result = [];
         foreach ($normalizedKeyValuePairs as $normalizedKey => $value) {

--- a/src/Storage/Adapter/AbstractZendServer.php
+++ b/src/Storage/Adapter/AbstractZendServer.php
@@ -73,7 +73,7 @@ abstract class AbstractZendServer extends AbstractAdapter
         $fetch   = $this->zdcFetchMulti($internalKeys);
         $result  = [];
         $prefixL = strlen($prefix);
-        foreach ($fetch as $k => & $v) {
+        foreach ($fetch as $k => $v) {
             $result[substr($k, $prefixL)] = $v;
         }
 
@@ -117,7 +117,7 @@ abstract class AbstractZendServer extends AbstractAdapter
         $fetch   = $this->zdcFetchMulti($internalKeys);
         $result  = [];
         $prefixL = strlen($prefix);
-        foreach ($fetch as $internalKey => & $value) {
+        foreach ($fetch as $internalKey => $value) {
             $result[] = substr($internalKey, $prefixL);
         }
 

--- a/src/Storage/Adapter/AbstractZendServer.php
+++ b/src/Storage/Adapter/AbstractZendServer.php
@@ -33,7 +33,7 @@ abstract class AbstractZendServer extends AbstractAdapter
      * @return mixed Data on success, null on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalGetItem(& $normalizedKey, & $success = null, & $casToken = null)
+    protected function internalGetItem($normalizedKey, & $success = null, & $casToken = null)
     {
         $namespace   = $this->getOptions()->getNamespace();
         $prefix      = ($namespace === '') ? '' : $namespace . self::NAMESPACE_SEPARATOR;
@@ -57,7 +57,7 @@ abstract class AbstractZendServer extends AbstractAdapter
      * @return array Associative array of keys and values
      * @throws Exception\ExceptionInterface
      */
-    protected function internalGetItems(array & $normalizedKeys)
+    protected function internalGetItems(array $normalizedKeys)
     {
         $namespace = $this->getOptions()->getNamespace();
         if ($namespace === '') {
@@ -87,7 +87,7 @@ abstract class AbstractZendServer extends AbstractAdapter
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalHasItem(& $normalizedKey)
+    protected function internalHasItem($normalizedKey)
     {
         $namespace = $this->getOptions()->getNamespace();
         $prefix    = ($namespace === '') ? '' : $namespace . self::NAMESPACE_SEPARATOR;
@@ -101,7 +101,7 @@ abstract class AbstractZendServer extends AbstractAdapter
      * @return array Array of found keys
      * @throws Exception\ExceptionInterface
      */
-    protected function internalHasItems(array & $normalizedKeys)
+    protected function internalHasItems(array $normalizedKeys)
     {
         $namespace = $this->getOptions()->getNamespace();
         if ($namespace === '') {
@@ -134,7 +134,7 @@ abstract class AbstractZendServer extends AbstractAdapter
      * @triggers getMetadatas.post(PostEvent)
      * @triggers getMetadatas.exception(ExceptionEvent)
      */
-    protected function internalGetMetadatas(array & $normalizedKeys)
+    protected function internalGetMetadatas(array $normalizedKeys)
     {
         $namespace = $this->getOptions()->getNamespace();
         if ($namespace === '') {
@@ -168,7 +168,7 @@ abstract class AbstractZendServer extends AbstractAdapter
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalSetItem(& $normalizedKey, & $value)
+    protected function internalSetItem($normalizedKey, $value)
     {
         $options   = $this->getOptions();
         $namespace = $options->getNamespace();
@@ -184,7 +184,7 @@ abstract class AbstractZendServer extends AbstractAdapter
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalRemoveItem(& $normalizedKey)
+    protected function internalRemoveItem($normalizedKey)
     {
         $namespace = $this->getOptions()->getNamespace();
         $prefix    = ($namespace === '') ? '' : $namespace . self::NAMESPACE_SEPARATOR;

--- a/src/Storage/Adapter/AdapterOptions.php
+++ b/src/Storage/Adapter/AdapterOptions.php
@@ -9,7 +9,6 @@
 
 namespace Zend\Cache\Storage\Adapter;
 
-use ArrayObject;
 use Zend\Cache\Exception;
 use Zend\Cache\Storage\Event;
 use Zend\Cache\Storage\StorageInterface;
@@ -242,7 +241,7 @@ class AdapterOptions extends AbstractOptions
     protected function triggerOptionEvent($optionName, $optionValue)
     {
         if ($this->adapter instanceof EventsCapableInterface) {
-            $event = new Event('option', $this->adapter, new ArrayObject([$optionName => $optionValue]));
+            $event = new Event('option', $this->adapter, [$optionName => $optionValue]);
             $this->adapter->getEventManager()->triggerEvent($event);
         }
     }

--- a/src/Storage/Adapter/Apc.php
+++ b/src/Storage/Adapter/Apc.php
@@ -714,7 +714,7 @@ class Apc extends AbstractAdapter implements
      * Normalize metadata to work with APC
      *
      * @param  array $metadata
-     * @return void
+     * @return array
      */
     protected function normalizeMetadata(array $metadata)
     {

--- a/src/Storage/Adapter/Apc.php
+++ b/src/Storage/Adapter/Apc.php
@@ -212,7 +212,7 @@ class Apc extends AbstractAdapter implements
      * @return mixed Data on success, null on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalGetItem(& $normalizedKey, & $success = null, & $casToken = null)
+    protected function internalGetItem($normalizedKey, & $success = null, & $casToken = null)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();
@@ -235,7 +235,7 @@ class Apc extends AbstractAdapter implements
      * @return array Associative array of keys and values
      * @throws Exception\ExceptionInterface
      */
-    protected function internalGetItems(array & $normalizedKeys)
+    protected function internalGetItems(array $normalizedKeys)
     {
         $options   = $this->getOptions();
         $namespace = $options->getNamespace();
@@ -268,7 +268,7 @@ class Apc extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalHasItem(& $normalizedKey)
+    protected function internalHasItem($normalizedKey)
     {
         $options   = $this->getOptions();
         $namespace = $options->getNamespace();
@@ -283,7 +283,7 @@ class Apc extends AbstractAdapter implements
      * @return array Array of found keys
      * @throws Exception\ExceptionInterface
      */
-    protected function internalHasItems(array & $normalizedKeys)
+    protected function internalHasItems(array $normalizedKeys)
     {
         $options   = $this->getOptions();
         $namespace = $options->getNamespace();
@@ -317,7 +317,7 @@ class Apc extends AbstractAdapter implements
      * @return array|bool Metadata on success, false on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalGetMetadata(& $normalizedKey)
+    protected function internalGetMetadata($normalizedKey)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();
@@ -352,7 +352,7 @@ class Apc extends AbstractAdapter implements
      * @triggers getMetadatas.post(PostEvent)
      * @triggers getMetadatas.exception(ExceptionEvent)
      */
-    protected function internalGetMetadatas(array & $normalizedKeys)
+    protected function internalGetMetadatas(array $normalizedKeys)
     {
         $keysRegExp = [];
         foreach ($normalizedKeys as $normalizedKey) {
@@ -397,7 +397,7 @@ class Apc extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalSetItem(& $normalizedKey, & $value)
+    protected function internalSetItem($normalizedKey, $value)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();
@@ -422,7 +422,7 @@ class Apc extends AbstractAdapter implements
      * @return array Array of not stored keys
      * @throws Exception\ExceptionInterface
      */
-    protected function internalSetItems(array & $normalizedKeyValuePairs)
+    protected function internalSetItems(array $normalizedKeyValuePairs)
     {
         $options   = $this->getOptions();
         $namespace = $options->getNamespace();
@@ -457,7 +457,7 @@ class Apc extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalAddItem(& $normalizedKey, & $value)
+    protected function internalAddItem($normalizedKey, $value)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();
@@ -486,7 +486,7 @@ class Apc extends AbstractAdapter implements
      * @return array Array of not stored keys
      * @throws Exception\ExceptionInterface
      */
-    protected function internalAddItems(array & $normalizedKeyValuePairs)
+    protected function internalAddItems(array $normalizedKeyValuePairs)
     {
         $options   = $this->getOptions();
         $namespace = $options->getNamespace();
@@ -521,7 +521,7 @@ class Apc extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalReplaceItem(& $normalizedKey, & $value)
+    protected function internalReplaceItem($normalizedKey, $value)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();
@@ -550,7 +550,7 @@ class Apc extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalRemoveItem(& $normalizedKey)
+    protected function internalRemoveItem($normalizedKey)
     {
         $options   = $this->getOptions();
         $namespace = $options->getNamespace();
@@ -565,7 +565,7 @@ class Apc extends AbstractAdapter implements
      * @return array Array of not removed keys
      * @throws Exception\ExceptionInterface
      */
-    protected function internalRemoveItems(array & $normalizedKeys)
+    protected function internalRemoveItems(array $normalizedKeys)
     {
         $options   = $this->getOptions();
         $namespace = $options->getNamespace();
@@ -598,7 +598,7 @@ class Apc extends AbstractAdapter implements
      * @return int|bool The new value on success, false on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalIncrementItem(& $normalizedKey, & $value)
+    protected function internalIncrementItem($normalizedKey, $value)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();
@@ -629,7 +629,7 @@ class Apc extends AbstractAdapter implements
      * @return int|bool The new value on success, false on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalDecrementItem(& $normalizedKey, & $value)
+    protected function internalDecrementItem($normalizedKey, $value)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();
@@ -743,7 +743,7 @@ class Apc extends AbstractAdapter implements
      * @see    getItem()
      * @see    setItem()
      */
-    protected function internalCheckAndSetItem(& $token, & $normalizedKey, & $value)
+    protected function internalCheckAndSetItem($token, $normalizedKey, $value)
     {
         if (is_int($token) && is_int($value)) {
             return apc_cas($normalizedKey, $token, $value);

--- a/src/Storage/Adapter/Apc.php
+++ b/src/Storage/Adapter/Apc.php
@@ -338,8 +338,7 @@ class Apc extends AbstractAdapter implements
             return false;
         }
 
-        $this->normalizeMetadata($metadata);
-        return $metadata;
+        return $this->normalizeMetadata($metadata);
     }
 
     /**
@@ -380,8 +379,7 @@ class Apc extends AbstractAdapter implements
                 continue;
             }
 
-            $this->normalizeMetadata($metadata);
-            $result[substr($internalKey, $prefixL)] = $metadata;
+            $result[substr($internalKey, $prefixL)] = $this->normalizeMetadata($metadata);
         }
 
         return $result;
@@ -718,10 +716,9 @@ class Apc extends AbstractAdapter implements
      * @param  array $metadata
      * @return void
      */
-    protected function normalizeMetadata(array & $metadata)
+    protected function normalizeMetadata(array $metadata)
     {
-        $apcMetadata = $metadata;
-        $metadata = [
+        return [
             'internal_key' => isset($metadata['key']) ? $metadata['key'] : $metadata['info'],
             'atime'        => isset($metadata['access_time']) ? $metadata['access_time'] : $metadata['atime'],
             'ctime'        => isset($metadata['creation_time']) ? $metadata['creation_time'] : $metadata['ctime'],

--- a/src/Storage/Adapter/Apcu.php
+++ b/src/Storage/Adapter/Apcu.php
@@ -207,7 +207,7 @@ class Apcu extends AbstractAdapter implements
      * @return mixed Data on success, null on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalGetItem(& $normalizedKey, & $success = null, & $casToken = null)
+    protected function internalGetItem($normalizedKey, & $success = null, & $casToken = null)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();
@@ -230,7 +230,7 @@ class Apcu extends AbstractAdapter implements
      * @return array Associative array of keys and values
      * @throws Exception\ExceptionInterface
      */
-    protected function internalGetItems(array & $normalizedKeys)
+    protected function internalGetItems(array $normalizedKeys)
     {
         $options   = $this->getOptions();
         $namespace = $options->getNamespace();
@@ -263,7 +263,7 @@ class Apcu extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalHasItem(& $normalizedKey)
+    protected function internalHasItem($normalizedKey)
     {
         $options   = $this->getOptions();
         $namespace = $options->getNamespace();
@@ -278,7 +278,7 @@ class Apcu extends AbstractAdapter implements
      * @return array Array of found keys
      * @throws Exception\ExceptionInterface
      */
-    protected function internalHasItems(array & $normalizedKeys)
+    protected function internalHasItems(array $normalizedKeys)
     {
         $options   = $this->getOptions();
         $namespace = $options->getNamespace();
@@ -312,7 +312,7 @@ class Apcu extends AbstractAdapter implements
      * @return array|bool Metadata on success, false on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalGetMetadata(& $normalizedKey)
+    protected function internalGetMetadata($normalizedKey)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();
@@ -328,8 +328,7 @@ class Apcu extends AbstractAdapter implements
             return false;
         }
 
-        $this->normalizeMetadata($metadata);
-        return $metadata;
+        return $this->normalizeMetadata($metadata);
     }
 
     /**
@@ -342,7 +341,7 @@ class Apcu extends AbstractAdapter implements
      * @triggers getMetadatas.post(PostEvent)
      * @triggers getMetadatas.exception(ExceptionEvent)
      */
-    protected function internalGetMetadatas(array & $normalizedKeys)
+    protected function internalGetMetadatas(array $normalizedKeys)
     {
         $keysRegExp = [];
         foreach ($normalizedKeys as $normalizedKey) {
@@ -365,8 +364,7 @@ class Apcu extends AbstractAdapter implements
         $it      = new BaseApcuIterator($pattern, $format, 100, APC_LIST_ACTIVE);
         $result  = [];
         foreach ($it as $internalKey => $metadata) {
-            $this->normalizeMetadata($metadata);
-            $result[substr($internalKey, $prefixL)] = $metadata;
+            $result[substr($internalKey, $prefixL)] = $this->normalizeMetadata($metadata);
         }
 
         return $result;
@@ -382,7 +380,7 @@ class Apcu extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalSetItem(& $normalizedKey, & $value)
+    protected function internalSetItem($normalizedKey, $value)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();
@@ -407,7 +405,7 @@ class Apcu extends AbstractAdapter implements
      * @return array Array of not stored keys
      * @throws Exception\ExceptionInterface
      */
-    protected function internalSetItems(array & $normalizedKeyValuePairs)
+    protected function internalSetItems(array $normalizedKeyValuePairs)
     {
         $options   = $this->getOptions();
         $namespace = $options->getNamespace();
@@ -442,7 +440,7 @@ class Apcu extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalAddItem(& $normalizedKey, & $value)
+    protected function internalAddItem($normalizedKey, $value)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();
@@ -471,7 +469,7 @@ class Apcu extends AbstractAdapter implements
      * @return array Array of not stored keys
      * @throws Exception\ExceptionInterface
      */
-    protected function internalAddItems(array & $normalizedKeyValuePairs)
+    protected function internalAddItems(array $normalizedKeyValuePairs)
     {
         $options   = $this->getOptions();
         $namespace = $options->getNamespace();
@@ -506,7 +504,7 @@ class Apcu extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalReplaceItem(& $normalizedKey, & $value)
+    protected function internalReplaceItem($normalizedKey, $value)
     {
         $options     = $this->getOptions();
         $ttl         = $options->getTtl();
@@ -539,7 +537,7 @@ class Apcu extends AbstractAdapter implements
      * @see    getItem()
      * @see    setItem()
      */
-    protected function internalCheckAndSetItem(& $token, & $normalizedKey, & $value)
+    protected function internalCheckAndSetItem($token, $normalizedKey, $value)
     {
         if (is_int($token) && is_int($value)) {
             return apcu_cas($normalizedKey, $token, $value);
@@ -555,7 +553,7 @@ class Apcu extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalRemoveItem(& $normalizedKey)
+    protected function internalRemoveItem($normalizedKey)
     {
         $options   = $this->getOptions();
         $namespace = $options->getNamespace();
@@ -570,7 +568,7 @@ class Apcu extends AbstractAdapter implements
      * @return array Array of not removed keys
      * @throws Exception\ExceptionInterface
      */
-    protected function internalRemoveItems(array & $normalizedKeys)
+    protected function internalRemoveItems(array $normalizedKeys)
     {
         $options   = $this->getOptions();
         $namespace = $options->getNamespace();
@@ -603,7 +601,7 @@ class Apcu extends AbstractAdapter implements
      * @return int|bool The new value on success, false on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalIncrementItem(& $normalizedKey, & $value)
+    protected function internalIncrementItem($normalizedKey, $value)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();
@@ -634,7 +632,7 @@ class Apcu extends AbstractAdapter implements
      * @return int|bool The new value on success, false on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalDecrementItem(& $normalizedKey, & $value)
+    protected function internalDecrementItem($normalizedKey, $value)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();
@@ -723,10 +721,9 @@ class Apcu extends AbstractAdapter implements
      * @param  array $metadata
      * @return void
      */
-    protected function normalizeMetadata(array & $metadata)
+    protected function normalizeMetadata(array $metadata)
     {
-        $apcMetadata = $metadata;
-        $metadata = [
+        return [
             'internal_key' => $metadata['key'],
             'atime'        => $metadata['access_time'],
             'ctime'        => $metadata['creation_time'],

--- a/src/Storage/Adapter/BlackHole.php
+++ b/src/Storage/Adapter/BlackHole.php
@@ -105,9 +105,9 @@ class BlackHole implements
     /**
      * Get an item.
      *
-     * @param  string  $key
-     * @param  bool $success
-     * @param  mixed   $casToken
+     * @param  string $key
+     * @param  bool   $success
+     * @param  mixed  $casToken
      * @return mixed Data on success, null on failure
      */
     public function getItem($key, & $success = null, & $casToken = null)

--- a/src/Storage/Adapter/Dba.php
+++ b/src/Storage/Adapter/Dba.php
@@ -325,7 +325,7 @@ class Dba extends AbstractAdapter implements
      * @return mixed Data on success, null on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalGetItem(& $normalizedKey, & $success = null, & $casToken = null)
+    protected function internalGetItem($normalizedKey, & $success = null, & $casToken = null)
     {
         $options   = $this->getOptions();
         $namespace = $options->getNamespace();
@@ -351,7 +351,7 @@ class Dba extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalHasItem(& $normalizedKey)
+    protected function internalHasItem($normalizedKey)
     {
         $options   = $this->getOptions();
         $namespace = $options->getNamespace();
@@ -371,7 +371,7 @@ class Dba extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalSetItem(& $normalizedKey, & $value)
+    protected function internalSetItem($normalizedKey, $value)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();
@@ -396,7 +396,7 @@ class Dba extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalAddItem(& $normalizedKey, & $value)
+    protected function internalAddItem($normalizedKey, $value)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();
@@ -429,7 +429,7 @@ class Dba extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalRemoveItem(& $normalizedKey)
+    protected function internalRemoveItem($normalizedKey)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();

--- a/src/Storage/Adapter/Filesystem.php
+++ b/src/Storage/Adapter/Filesystem.php
@@ -25,7 +25,6 @@ use Zend\Cache\Storage\OptimizableInterface;
 use Zend\Cache\Storage\TaggableInterface;
 use Zend\Cache\Storage\TotalSpaceCapableInterface;
 use Zend\Stdlib\ErrorHandler;
-use ArrayObject;
 
 class Filesystem extends AbstractAdapter implements
     AvailableSpaceCapableInterface,
@@ -166,7 +165,7 @@ class Filesystem extends AbstractAdapter implements
             $result = false;
             return $this->triggerException(
                 __FUNCTION__,
-                new ArrayObject(),
+                [],
                 $result,
                 new Exception\RuntimeException('Failed to clear expired items', 0, $error)
             );

--- a/src/Storage/Adapter/Filesystem.php
+++ b/src/Storage/Adapter/Filesystem.php
@@ -262,7 +262,7 @@ class Filesystem extends AbstractAdapter implements
      */
     public function setTags($key, array $tags)
     {
-        $this->normalizeKey($key);
+        $key = $this->normalizeKey($key);
         if (!$this->internalHasItem($key)) {
             return false;
         }
@@ -286,7 +286,7 @@ class Filesystem extends AbstractAdapter implements
      */
     public function getTags($key)
     {
-        $this->normalizeKey($key);
+        $key = $this->normalizeKey($key);
         if (!$this->internalHasItem($key)) {
             return false;
         }

--- a/src/Storage/Adapter/Filesystem.php
+++ b/src/Storage/Adapter/Filesystem.php
@@ -927,12 +927,12 @@ class Filesystem extends AbstractAdapter implements
     {
         // create an associated array of files and contents to write
         $contents = [];
-        foreach ($normalizedKeyValuePairs as $key => & $value) {
+        foreach ($normalizedKeyValuePairs as $key => $value) {
             $filespec = $this->getFileSpec($key);
             $this->prepareDirectoryStructure($filespec);
 
             // *.dat file
-            $contents[$filespec . '.dat'] = & $value;
+            $contents[$filespec . '.dat'] = $value;
 
             // *.tag file
             $this->unlink($filespec . '.tag');
@@ -943,7 +943,7 @@ class Filesystem extends AbstractAdapter implements
             $nonBlocking = count($contents) > 1;
             $wouldblock  = null;
 
-            foreach ($contents as $file => & $content) {
+            foreach ($contents as $file => $content) {
                 $this->putFileContent($file, $content, $nonBlocking, $wouldblock);
                 if (!$nonBlocking || !$wouldblock) {
                     unset($contents[$file]);

--- a/src/Storage/Adapter/Filesystem.php
+++ b/src/Storage/Adapter/Filesystem.php
@@ -521,7 +521,7 @@ class Filesystem extends AbstractAdapter implements
      * @throws Exception\ExceptionInterface
      * @throws BaseException
      */
-    protected function internalGetItem(& $normalizedKey, & $success = null, & $casToken = null)
+    protected function internalGetItem($normalizedKey, & $success = null, & $casToken = null)
     {
         if (!$this->internalHasItem($normalizedKey)) {
             $success = false;
@@ -551,7 +551,7 @@ class Filesystem extends AbstractAdapter implements
      * @return array Associative array of keys and values
      * @throws Exception\ExceptionInterface
      */
-    protected function internalGetItems(array & $normalizedKeys)
+    protected function internalGetItems(array $normalizedKeys)
     {
         $keys    = $normalizedKeys; // Don't change argument passed by reference
         $result  = [];
@@ -634,7 +634,7 @@ class Filesystem extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalHasItem(& $normalizedKey)
+    protected function internalHasItem($normalizedKey)
     {
         $file = $this->getFileSpec($normalizedKey) . '.dat';
         if (!file_exists($file)) {
@@ -697,7 +697,7 @@ class Filesystem extends AbstractAdapter implements
      * @param string $normalizedKey
      * @return array|bool Metadata on success, false on failure
      */
-    protected function internalGetMetadata(& $normalizedKey)
+    protected function internalGetMetadata($normalizedKey)
     {
         if (!$this->internalHasItem($normalizedKey)) {
             return false;
@@ -730,7 +730,7 @@ class Filesystem extends AbstractAdapter implements
      * @return array Associative array of keys and metadata
      * @throws Exception\ExceptionInterface
      */
-    protected function internalGetMetadatas(array & $normalizedKeys)
+    protected function internalGetMetadatas(array $normalizedKeys)
     {
         $options = $this->getOptions();
         $result  = [];
@@ -896,7 +896,7 @@ class Filesystem extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalSetItem(& $normalizedKey, & $value)
+    protected function internalSetItem($normalizedKey, $value)
     {
         $filespec = $this->getFileSpec($normalizedKey);
         $this->prepareDirectoryStructure($filespec);
@@ -923,7 +923,7 @@ class Filesystem extends AbstractAdapter implements
      * @return array Array of not stored keys
      * @throws Exception\ExceptionInterface
      */
-    protected function internalSetItems(array & $normalizedKeyValuePairs)
+    protected function internalSetItems(array $normalizedKeyValuePairs)
     {
         // create an associated array of files and contents to write
         $contents = [];
@@ -990,7 +990,7 @@ class Filesystem extends AbstractAdapter implements
      * @see    getItem()
      * @see    setItem()
      */
-    protected function internalCheckAndSetItem(& $token, & $normalizedKey, & $value)
+    protected function internalCheckAndSetItem($token, $normalizedKey, $value)
     {
         if (!$this->internalHasItem($normalizedKey)) {
             return false;
@@ -1055,7 +1055,7 @@ class Filesystem extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalTouchItem(& $normalizedKey)
+    protected function internalTouchItem($normalizedKey)
     {
         if (!$this->internalHasItem($normalizedKey)) {
             return false;
@@ -1122,7 +1122,7 @@ class Filesystem extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalRemoveItem(& $normalizedKey)
+    protected function internalRemoveItem($normalizedKey)
     {
         $filespec = $this->getFileSpec($normalizedKey);
         if (!file_exists($filespec . '.dat')) {

--- a/src/Storage/Adapter/Memcache.php
+++ b/src/Storage/Adapter/Memcache.php
@@ -212,7 +212,7 @@ class Memcache extends AbstractAdapter implements
      * @return mixed Data on success, null on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalGetItem(& $normalizedKey, & $success = null, & $casToken = null)
+    protected function internalGetItem($normalizedKey, & $success = null, & $casToken = null)
     {
         $memc        = $this->getMemcacheResource();
         $internalKey = $this->namespacePrefix . $normalizedKey;
@@ -234,7 +234,7 @@ class Memcache extends AbstractAdapter implements
      * @return array Associative array of keys and values
      * @throws Exception\ExceptionInterface
      */
-    protected function internalGetItems(array & $normalizedKeys)
+    protected function internalGetItems(array $normalizedKeys)
     {
         $memc = $this->getMemcacheResource();
 
@@ -267,7 +267,7 @@ class Memcache extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalHasItem(& $normalizedKey)
+    protected function internalHasItem($normalizedKey)
     {
         $memc  = $this->getMemcacheResource();
         $value = $memc->get($this->namespacePrefix . $normalizedKey);
@@ -281,7 +281,7 @@ class Memcache extends AbstractAdapter implements
      * @return array Array of found keys
      * @throws Exception\ExceptionInterface
      */
-    protected function internalHasItems(array & $normalizedKeys)
+    protected function internalHasItems(array $normalizedKeys)
     {
         $memc = $this->getMemcacheResource();
 
@@ -315,7 +315,7 @@ class Memcache extends AbstractAdapter implements
      * @return array Associative array of keys and metadata
      * @throws Exception\ExceptionInterface
      */
-    protected function internalGetMetadatas(array & $normalizedKeys)
+    protected function internalGetMetadatas(array $normalizedKeys)
     {
         $memc = $this->getMemcacheResource();
 
@@ -354,7 +354,7 @@ class Memcache extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalSetItem(& $normalizedKey, & $value)
+    protected function internalSetItem($normalizedKey, $value)
     {
         $memc       = $this->getMemcacheResource();
         $expiration = $this->expirationTime();
@@ -375,7 +375,7 @@ class Memcache extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalAddItem(& $normalizedKey, & $value)
+    protected function internalAddItem($normalizedKey, $value)
     {
         $memc       = $this->getMemcacheResource();
         $expiration = $this->expirationTime();
@@ -392,7 +392,7 @@ class Memcache extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalReplaceItem(& $normalizedKey, & $value)
+    protected function internalReplaceItem($normalizedKey, $value)
     {
         $memc       = $this->getMemcacheResource();
         $expiration = $this->expirationTime();
@@ -408,7 +408,7 @@ class Memcache extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalRemoveItem(& $normalizedKey)
+    protected function internalRemoveItem($normalizedKey)
     {
         $memc   = $this->getMemcacheResource();
         // Delete's second parameter (timeout) is deprecated and not supported.
@@ -425,7 +425,7 @@ class Memcache extends AbstractAdapter implements
      * @return int|bool The new value on success, false on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalIncrementItem(& $normalizedKey, & $value)
+    protected function internalIncrementItem($normalizedKey, $value)
     {
         $memc        = $this->getMemcacheResource();
         $internalKey = $this->namespacePrefix . $normalizedKey;
@@ -454,7 +454,7 @@ class Memcache extends AbstractAdapter implements
      * @return int|bool The new value on success, false on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalDecrementItem(& $normalizedKey, & $value)
+    protected function internalDecrementItem($normalizedKey, $value)
     {
         $memc        = $this->getMemcacheResource();
         $internalKey = $this->namespacePrefix . $normalizedKey;

--- a/src/Storage/Adapter/Memcache.php
+++ b/src/Storage/Adapter/Memcache.php
@@ -138,7 +138,7 @@ class Memcache extends AbstractAdapter implements
      * @param  mixed $value
      * @return int
      */
-    protected function getWriteFlag(& $value)
+    protected function getWriteFlag($value)
     {
         if (!$this->getOptions()->getCompression()) {
             return 0;
@@ -251,8 +251,8 @@ class Memcache extends AbstractAdapter implements
         if ($this->namespacePrefix !== '') {
             $tmp            = [];
             $nsPrefixLength = strlen($this->namespacePrefix);
-            foreach ($result as $internalKey => & $value) {
-                $tmp[substr($internalKey, $nsPrefixLength)] = & $value;
+            foreach ($result as $internalKey => $value) {
+                $tmp[substr($internalKey, $nsPrefixLength)] = $value;
             }
             $result = $tmp;
         }

--- a/src/Storage/Adapter/MemcacheResourceManager.php
+++ b/src/Storage/Adapter/MemcacheResourceManager.php
@@ -126,7 +126,7 @@ class MemcacheResourceManager
             }
 
             $resourceOptions = [
-                'servers' => [],
+                'servers'                   => [],
                 'auto_compress_threshold'   => null,
                 'auto_compress_min_savings' => null,
             ];
@@ -137,14 +137,12 @@ class MemcacheResourceManager
                 $resource['auto_compress_threshold'],
                 $resource['auto_compress_min_savings']
             );
-            $this->normalizeServers($resource['servers']);
+            $resource['servers'] = $this->normalizeServers($resource['servers']);
         }
 
-        $this->normalizeServerDefaults($serverDefaults);
-
-        $this->resources[$id] = $resource;
+        $this->resources[$id]        = $resource;
         $this->failureCallbacks[$id] = $failureCallback;
-        $this->serverDefaults[$id] = $serverDefaults;
+        $this->serverDefaults[$id]   = $this->normalizeServerDefaults($serverDefaults);
 
         return $this;
     }
@@ -214,7 +212,7 @@ class MemcacheResourceManager
             throw new Exception\RuntimeException("No resource with id '{$id}'");
         }
 
-        $resource = & $this->resources[$id];
+        $resource = $this->resources[$id];
         if ($resource instanceof MemcacheResource) {
             // Cannot get options from Memcache resource once created
             throw new Exception\RuntimeException("Cannot get compress threshold once resource is created");
@@ -265,7 +263,7 @@ class MemcacheResourceManager
             throw new Exception\RuntimeException("No resource with id '{$id}'");
         }
 
-        $resource = & $this->resources[$id];
+        $resource = $this->resources[$id];
         if ($resource instanceof MemcacheResource) {
             // Cannot get options from Memcache resource once created
             throw new Exception\RuntimeException("Cannot get compress min savings once resource is created");
@@ -320,8 +318,7 @@ class MemcacheResourceManager
             ]);
         }
 
-        $this->normalizeServerDefaults($serverDefaults);
-        $this->serverDefaults[$id] = $serverDefaults;
+        $this->serverDefaults[$id] = $this->normalizeServerDefaults($serverDefaults);
 
         return $this;
     }
@@ -342,10 +339,11 @@ class MemcacheResourceManager
     }
 
     /**
-     * @param array $serverDefaults
+     * @param  array $serverDefaults
+     * @return array
      * @throws Exception\InvalidArgumentException
      */
-    protected function normalizeServerDefaults(& $serverDefaults)
+    protected function normalizeServerDefaults($serverDefaults)
     {
         if (!is_array($serverDefaults) && !($serverDefaults instanceof Traversable)) {
             throw new Exception\InvalidArgumentException(
@@ -355,9 +353,9 @@ class MemcacheResourceManager
 
         // Defaults
         $result = [
-            'persistent' => true,
-            'weight' => 1,
-            'timeout' => 1, // seconds
+            'persistent'     => true,
+            'weight'         => 1,
+            'timeout'        => 1,  // seconds
             'retry_interval' => 15, // seconds
         ];
 
@@ -375,7 +373,7 @@ class MemcacheResourceManager
             $result[$key] = $value;
         }
 
-        $serverDefaults = $result;
+        return $result;
     }
 
     /**
@@ -423,7 +421,7 @@ class MemcacheResourceManager
             throw new Exception\RuntimeException("No resource with id '{$id}'");
         }
 
-        $resource = & $this->resources[$id];
+        $resource = $this->resources[$id];
         if ($resource instanceof MemcacheResource) {
             throw new Exception\RuntimeException("Cannot get server list once resource is created");
         }
@@ -445,8 +443,7 @@ class MemcacheResourceManager
             ]);
         }
 
-        $this->normalizeServers($servers);
-
+        $servers  = $this->normalizeServers($servers);
         $resource = & $this->resources[$id];
         if ($resource instanceof MemcacheResource) {
             foreach ($servers as $server) {
@@ -515,9 +512,10 @@ class MemcacheResourceManager
      * Normalize a list of servers into the following format:
      * array(array('host' => <host>, 'port' => <port>, 'weight' => <weight>)[, ...])
      *
-     * @param string|array $servers
+     * @param  string|array $servers
+     * @return array
      */
-    protected function normalizeServers(& $servers)
+    protected function normalizeServers($servers)
     {
         if (is_string($servers)) {
             // Convert string into a list of servers
@@ -526,11 +524,11 @@ class MemcacheResourceManager
 
         $result = [];
         foreach ($servers as $server) {
-            $this->normalizeServer($server);
+            $server = $this->normalizeServer($server);
             $result[$server['host'] . ':' . $server['port']] = $server;
         }
 
-        $servers = array_values($result);
+        return array_values($result);
     }
 
     /**
@@ -541,15 +539,16 @@ class MemcacheResourceManager
      *   'timeout' => <timeout>, 'retry_interval' => <retryInterval>,
      * )
      *
-     * @param string|array $server
+     * @param  string|array $server
+     * @return array
      * @throws Exception\InvalidArgumentException
      */
-    protected function normalizeServer(& $server)
+    protected function normalizeServer($server)
     {
         // WARNING: The order of this array is important.
         // Used for converting an ordered array to a keyed array.
         // Append new options, do not insert or you will break BC.
-        $sTmp = [
+        $result = [
             'host'           => null,
             'port'           => 11211,
             'weight'         => null,
@@ -569,11 +568,11 @@ class MemcacheResourceManager
                 // Convert ordered array to keyed array
                 // array(<host>[, <port>[, <weight>[, <status>[, <persistent>[, <timeout>[, <retryInterval>]]]]]])
                 $server = array_combine(
-                    array_slice(array_keys($sTmp), 0, count($server)),
+                    array_slice(array_keys($result), 0, count($server)),
                     $server
                 );
             }
-            $sTmp = array_merge($sTmp, $server);
+            $result = array_merge($result, $server);
         } elseif (is_string($server)) {
             // parse server from URI host{:?port}{?weight}
             $server = trim($server);
@@ -586,20 +585,20 @@ class MemcacheResourceManager
                 throw new Exception\InvalidArgumentException("Invalid server given");
             }
 
-            $sTmp = array_merge($sTmp, array_intersect_key($urlParts, $sTmp));
+            $result = array_merge($result, array_intersect_key($urlParts, $result));
             if (isset($urlParts['query'])) {
                 $query = null;
                 parse_str($urlParts['query'], $query);
-                $sTmp = array_merge($sTmp, array_intersect_key($query, $sTmp));
+                $result = array_merge($result, array_intersect_key($query, $result));
             }
         }
 
-        if (!$sTmp['host']) {
+        if (!$result['host']) {
             throw new Exception\InvalidArgumentException('Missing required server host');
         }
 
         // Filter values
-        foreach ($sTmp as $key => $value) {
+        foreach ($result as $key => $value) {
             if (isset($value)) {
                 switch ($key) {
                     case 'host':
@@ -617,16 +616,12 @@ class MemcacheResourceManager
                         break;
                 }
             }
-            $sTmp[$key] = $value;
+            $result[$key] = $value;
         }
-        $sTmp = array_filter(
-            $sTmp,
-            function ($val) {
-                return isset($val);
-            }
-        );
 
-        $server = $sTmp;
+        return array_filter($result, function ($val) {
+                return isset($val);
+        });
     }
 
     /**

--- a/src/Storage/Adapter/MemcacheResourceManager.php
+++ b/src/Storage/Adapter/MemcacheResourceManager.php
@@ -238,13 +238,12 @@ class MemcacheResourceManager
 
         $this->normalizeAutoCompressThreshold($threshold, $minSavings);
 
-        $resource = & $this->resources[$id];
-        if ($resource instanceof MemcacheResource) {
-            $this->setResourceAutoCompressThreshold($resource, $threshold, $minSavings);
+        if ($this->resources[$id] instanceof MemcacheResource) {
+            $this->setResourceAutoCompressThreshold($this->resources[$id], $threshold, $minSavings);
         } else {
-            $resource['auto_compress_threshold'] = $threshold;
+            $this->resources[$id]['auto_compress_threshold'] = $threshold;
             if ($minSavings !== false) {
-                $resource['auto_compress_min_savings'] = $minSavings;
+                $this->resources[$id]['auto_compress_min_savings'] = $minSavings;
             }
         }
         return $this;
@@ -283,19 +282,16 @@ class MemcacheResourceManager
     {
         if (!$this->hasResource($id)) {
             return $this->setResource($id, [
-                'auto_compress_min_savings' => $minSavings,
+                'auto_compress_min_savings' => (float) $minSavings,
             ]);
         }
 
-        $minSavings = (float) $minSavings;
-
-        $resource = & $this->resources[$id];
-        if ($resource instanceof MemcacheResource) {
+        if ($this->resources[$id] instanceof MemcacheResource) {
             throw new Exception\RuntimeException(
                 "Cannot set compress min savings without a threshold value once a resource is created"
             );
         } else {
-            $resource['auto_compress_min_savings'] = $minSavings;
+            $this->resources[$id]['auto_compress_min_savings'] = (float) $minSavings;
         }
         return $this;
     }
@@ -444,7 +440,7 @@ class MemcacheResourceManager
         }
 
         $servers  = $this->normalizeServers($servers);
-        $resource = & $this->resources[$id];
+        $resource = $this->resources[$id];
         if ($resource instanceof MemcacheResource) {
             foreach ($servers as $server) {
                 $this->addServerToResource(
@@ -456,7 +452,7 @@ class MemcacheResourceManager
             }
         } else {
             // don't add servers twice
-            $resource['servers'] = array_merge(
+            $this->resources[$id]['servers'] = array_merge(
                 $resource['servers'],
                 array_udiff($servers, $resource['servers'], [$this, 'compareServers'])
             );

--- a/src/Storage/Adapter/Memcached.php
+++ b/src/Storage/Adapter/Memcached.php
@@ -198,7 +198,7 @@ class Memcached extends AbstractAdapter implements
      * @return mixed Data on success, null on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalGetItem(& $normalizedKey, & $success = null, & $casToken = null)
+    protected function internalGetItem($normalizedKey, & $success = null, & $casToken = null)
     {
         $memc        = $this->getMemcachedResource();
         $internalKey = $this->namespacePrefix . $normalizedKey;
@@ -231,7 +231,7 @@ class Memcached extends AbstractAdapter implements
      * @return array Associative array of keys and values
      * @throws Exception\ExceptionInterface
      */
-    protected function internalGetItems(array & $normalizedKeys)
+    protected function internalGetItems(array $normalizedKeys)
     {
         $memc = $this->getMemcachedResource();
 
@@ -270,7 +270,7 @@ class Memcached extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalHasItem(& $normalizedKey)
+    protected function internalHasItem($normalizedKey)
     {
         $memc  = $this->getMemcachedResource();
         $value = $memc->get($this->namespacePrefix . $normalizedKey);
@@ -295,7 +295,7 @@ class Memcached extends AbstractAdapter implements
      * @return array Array of found keys
      * @throws Exception\ExceptionInterface
      */
-    protected function internalHasItems(array & $normalizedKeys)
+    protected function internalHasItems(array $normalizedKeys)
     {
         return array_keys($this->internalGetItems($normalizedKeys));
     }
@@ -307,7 +307,7 @@ class Memcached extends AbstractAdapter implements
      * @return array Associative array of keys and metadata
      * @throws Exception\ExceptionInterface
      */
-    protected function internalGetMetadatas(array & $normalizedKeys)
+    protected function internalGetMetadatas(array $normalizedKeys)
     {
         return array_fill_keys(array_keys($this->internalGetItems($normalizedKeys)), []);
     }
@@ -322,7 +322,7 @@ class Memcached extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalSetItem(& $normalizedKey, & $value)
+    protected function internalSetItem($normalizedKey, $value)
     {
         $memc       = $this->getMemcachedResource();
         $expiration = $this->expirationTime();
@@ -340,7 +340,7 @@ class Memcached extends AbstractAdapter implements
      * @return array Array of not stored keys
      * @throws Exception\ExceptionInterface
      */
-    protected function internalSetItems(array & $normalizedKeyValuePairs)
+    protected function internalSetItems(array $normalizedKeyValuePairs)
     {
         $memc       = $this->getMemcachedResource();
         $expiration = $this->expirationTime();
@@ -365,7 +365,7 @@ class Memcached extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalAddItem(& $normalizedKey, & $value)
+    protected function internalAddItem($normalizedKey, $value)
     {
         $memc       = $this->getMemcachedResource();
         $expiration = $this->expirationTime();
@@ -387,7 +387,7 @@ class Memcached extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalReplaceItem(& $normalizedKey, & $value)
+    protected function internalReplaceItem($normalizedKey, $value)
     {
         $memc       = $this->getMemcachedResource();
         $expiration = $this->expirationTime();
@@ -413,7 +413,7 @@ class Memcached extends AbstractAdapter implements
      * @see    getItem()
      * @see    setItem()
      */
-    protected function internalCheckAndSetItem(& $token, & $normalizedKey, & $value)
+    protected function internalCheckAndSetItem($token, $normalizedKey, $value)
     {
         $memc       = $this->getMemcachedResource();
         $expiration = $this->expirationTime();
@@ -436,7 +436,7 @@ class Memcached extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalRemoveItem(& $normalizedKey)
+    protected function internalRemoveItem($normalizedKey)
     {
         $memc   = $this->getMemcachedResource();
         $result = $memc->delete($this->namespacePrefix . $normalizedKey);
@@ -460,7 +460,7 @@ class Memcached extends AbstractAdapter implements
      * @return array Array of not removed keys
      * @throws Exception\ExceptionInterface
      */
-    protected function internalRemoveItems(array & $normalizedKeys)
+    protected function internalRemoveItems(array $normalizedKeys)
     {
         $memc = $this->getMemcachedResource();
 
@@ -503,7 +503,7 @@ class Memcached extends AbstractAdapter implements
      * @return int|bool The new value on success, false on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalIncrementItem(& $normalizedKey, & $value)
+    protected function internalIncrementItem($normalizedKey, $value)
     {
         $memc        = $this->getMemcachedResource();
         $internalKey = $this->namespacePrefix . $normalizedKey;
@@ -536,7 +536,7 @@ class Memcached extends AbstractAdapter implements
      * @return int|bool The new value on success, false on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalDecrementItem(& $normalizedKey, & $value)
+    protected function internalDecrementItem($normalizedKey, $value)
     {
         $memc        = $this->getMemcachedResource();
         $internalKey = $this->namespacePrefix . $normalizedKey;

--- a/src/Storage/Adapter/Memory.php
+++ b/src/Storage/Adapter/Memory.php
@@ -293,7 +293,7 @@ class Memory extends AbstractAdapter implements
      * @return mixed Data on success, null on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalGetItem(& $normalizedKey, & $success = null, & $casToken = null)
+    protected function internalGetItem($normalizedKey, & $success = null, & $casToken = null)
     {
         $options = $this->getOptions();
         $ns      = $options->getNamespace();
@@ -321,7 +321,7 @@ class Memory extends AbstractAdapter implements
      * @return array Associative array of keys and values
      * @throws Exception\ExceptionInterface
      */
-    protected function internalGetItems(array & $normalizedKeys)
+    protected function internalGetItems(array $normalizedKeys)
     {
         $options = $this->getOptions();
         $ns      = $options->getNamespace();
@@ -351,7 +351,7 @@ class Memory extends AbstractAdapter implements
      * @param  string $normalizedKey
      * @return bool
      */
-    protected function internalHasItem(& $normalizedKey)
+    protected function internalHasItem($normalizedKey)
     {
         $options = $this->getOptions();
         $ns      = $options->getNamespace();
@@ -374,7 +374,7 @@ class Memory extends AbstractAdapter implements
      * @param array $normalizedKeys
      * @return array Array of found keys
      */
-    protected function internalHasItems(array & $normalizedKeys)
+    protected function internalHasItems(array $normalizedKeys)
     {
         $options = $this->getOptions();
         $ns      = $options->getNamespace();
@@ -409,7 +409,7 @@ class Memory extends AbstractAdapter implements
      * @triggers getMetadata.post(PostEvent)
      * @triggers getMetadata.exception(ExceptionEvent)
      */
-    protected function internalGetMetadata(& $normalizedKey)
+    protected function internalGetMetadata($normalizedKey)
     {
         if (!$this->internalHasItem($normalizedKey)) {
             return false;
@@ -431,7 +431,7 @@ class Memory extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalSetItem(& $normalizedKey, & $value)
+    protected function internalSetItem($normalizedKey, $value)
     {
         $options = $this->getOptions();
 
@@ -455,7 +455,7 @@ class Memory extends AbstractAdapter implements
      * @return array Array of not stored keys
      * @throws Exception\ExceptionInterface
      */
-    protected function internalSetItems(array & $normalizedKeyValuePairs)
+    protected function internalSetItems(array $normalizedKeyValuePairs)
     {
         $options = $this->getOptions();
 
@@ -488,7 +488,7 @@ class Memory extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalAddItem(& $normalizedKey, & $value)
+    protected function internalAddItem($normalizedKey, $value)
     {
         $options = $this->getOptions();
 
@@ -515,7 +515,7 @@ class Memory extends AbstractAdapter implements
      * @return array Array of not stored keys
      * @throws Exception\ExceptionInterface
      */
-    protected function internalAddItems(array & $normalizedKeyValuePairs)
+    protected function internalAddItems(array $normalizedKeyValuePairs)
     {
         $options = $this->getOptions();
 
@@ -553,7 +553,7 @@ class Memory extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalReplaceItem(& $normalizedKey, & $value)
+    protected function internalReplaceItem($normalizedKey, $value)
     {
         $ns = $this->getOptions()->getNamespace();
         if (!isset($this->data[$ns][$normalizedKey])) {
@@ -571,7 +571,7 @@ class Memory extends AbstractAdapter implements
      * @return array Array of not stored keys
      * @throws Exception\ExceptionInterface
      */
-    protected function internalReplaceItems(array & $normalizedKeyValuePairs)
+    protected function internalReplaceItems(array $normalizedKeyValuePairs)
     {
         $ns = $this->getOptions()->getNamespace();
         if (!isset($this->data[$ns])) {
@@ -598,7 +598,7 @@ class Memory extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalTouchItem(& $normalizedKey)
+    protected function internalTouchItem($normalizedKey)
     {
         $ns = $this->getOptions()->getNamespace();
 
@@ -617,7 +617,7 @@ class Memory extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalRemoveItem(& $normalizedKey)
+    protected function internalRemoveItem($normalizedKey)
     {
         $ns = $this->getOptions()->getNamespace();
         if (!isset($this->data[$ns][$normalizedKey])) {
@@ -642,7 +642,7 @@ class Memory extends AbstractAdapter implements
      * @return int|bool The new value on success, false on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalIncrementItem(& $normalizedKey, & $value)
+    protected function internalIncrementItem($normalizedKey, $value)
     {
         $ns = $this->getOptions()->getNamespace();
         if (isset($this->data[$ns][$normalizedKey])) {
@@ -667,7 +667,7 @@ class Memory extends AbstractAdapter implements
      * @return int|bool The new value on success, false on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalDecrementItem(& $normalizedKey, & $value)
+    protected function internalDecrementItem($normalizedKey, $value)
     {
         $ns = $this->getOptions()->getNamespace();
         if (isset($this->data[$ns][$normalizedKey])) {

--- a/src/Storage/Adapter/Memory.php
+++ b/src/Storage/Adapter/Memory.php
@@ -118,7 +118,7 @@ class Memory extends AbstractAdapter implements
         $keys = [];
 
         if (isset($this->data[$ns])) {
-            foreach ($this->data[$ns] as $key => & $tmp) {
+            foreach ($this->data[$ns] as $key => $tmp) {
                 if ($this->internalHasItem($key)) {
                     $keys[] = $key;
                 }
@@ -160,10 +160,9 @@ class Memory extends AbstractAdapter implements
             return true;
         }
 
-        $data = & $this->data[$ns];
-        foreach ($data as $key => & $item) {
-            if (microtime(true) >= $data[$key][1] + $ttl) {
-                unset($data[$key]);
+        foreach ($this->data[$ns] as $key => $item) {
+            if (microtime(true) >= $this->data[$ns][$key][1] + $ttl) {
+                unset($this->data[$ns][$key]);
             }
         }
 
@@ -204,10 +203,9 @@ class Memory extends AbstractAdapter implements
         }
 
         $prefixL = strlen($prefix);
-        $data    = & $this->data[$ns];
-        foreach ($data as $key => & $item) {
+        foreach ($this->data[$ns] as $key => $item) {
             if (substr($key, 0, $prefixL) === $prefix) {
-                unset($data[$key]);
+                unset($this->data[$ns][$key]);
             }
         }
 
@@ -269,12 +267,11 @@ class Memory extends AbstractAdapter implements
         }
 
         $tagCount = count($tags);
-        $data     = & $this->data[$ns];
-        foreach ($data as $key => & $item) {
+        foreach ($this->data[$ns] as $key => $item) {
             if (isset($item['tags'])) {
                 $diff = array_diff($tags, $item['tags']);
                 if (($disjunction && count($diff) < $tagCount) || (!$disjunction && !$diff)) {
-                    unset($data[$key]);
+                    unset($this->data[$ns][$key]);
                 }
             }
         }
@@ -299,7 +296,7 @@ class Memory extends AbstractAdapter implements
         $ns      = $options->getNamespace();
         $success = isset($this->data[$ns][$normalizedKey]);
         if ($success) {
-            $data = & $this->data[$ns][$normalizedKey];
+            $data = $this->data[$ns][$normalizedKey];
             $ttl  = $options->getTtl();
             if ($ttl && microtime(true) >= ($data[1] + $ttl)) {
                 $success = false;
@@ -329,7 +326,7 @@ class Memory extends AbstractAdapter implements
             return [];
         }
 
-        $data = & $this->data[$ns];
+        $data = $this->data[$ns];
         $ttl  = $options->getTtl();
         $now  = microtime(true);
 
@@ -382,7 +379,7 @@ class Memory extends AbstractAdapter implements
             return [];
         }
 
-        $data = & $this->data[$ns];
+        $data = $this->data[$ns];
         $ttl  = $options->getTtl();
         $now  = microtime(true);
 
@@ -471,10 +468,9 @@ class Memory extends AbstractAdapter implements
             $this->data[$ns] = [];
         }
 
-        $data = & $this->data[$ns];
-        $now  = microtime(true);
+        $now = microtime(true);
         foreach ($normalizedKeyValuePairs as $normalizedKey => $value) {
-            $data[$normalizedKey] = [$value, $now];
+            $this->data[$ns][$normalizedKey] = [$value, $now];
         }
 
         return [];
@@ -532,13 +528,12 @@ class Memory extends AbstractAdapter implements
         }
 
         $result = [];
-        $data   = & $this->data[$ns];
         $now    = microtime(true);
         foreach ($normalizedKeyValuePairs as $normalizedKey => $value) {
-            if (isset($data[$normalizedKey])) {
+            if (isset($this->data[$ns][$normalizedKey])) {
                 $result[] = $normalizedKey;
             } else {
-                $data[$normalizedKey] = [$value, $now];
+                $this->data[$ns][$normalizedKey] = [$value, $now];
             }
         }
 
@@ -579,12 +574,11 @@ class Memory extends AbstractAdapter implements
         }
 
         $result = [];
-        $data   = & $this->data[$ns];
         foreach ($normalizedKeyValuePairs as $normalizedKey => $value) {
-            if (!isset($data[$normalizedKey])) {
+            if (!isset($this->data[$ns][$normalizedKey])) {
                 $result[] = $normalizedKey;
             } else {
-                $data[$normalizedKey] = [$value, microtime(true)];
+                $this->data[$ns][$normalizedKey] = [$value, microtime(true)];
             }
         }
 
@@ -646,10 +640,9 @@ class Memory extends AbstractAdapter implements
     {
         $ns = $this->getOptions()->getNamespace();
         if (isset($this->data[$ns][$normalizedKey])) {
-            $data = & $this->data[$ns][$normalizedKey];
-            $data[0]+= $value;
-            $data[1] = microtime(true);
-            $newValue = $data[0];
+            $this->data[$ns][$normalizedKey][0] += $value;
+            $this->data[$ns][$normalizedKey][1]  = microtime(true);
+            $newValue = $this->data[$ns][$normalizedKey][0];
         } else {
             // initial value
             $newValue                        = $value;
@@ -671,10 +664,9 @@ class Memory extends AbstractAdapter implements
     {
         $ns = $this->getOptions()->getNamespace();
         if (isset($this->data[$ns][$normalizedKey])) {
-            $data = & $this->data[$ns][$normalizedKey];
-            $data[0]-= $value;
-            $data[1] = microtime(true);
-            $newValue = $data[0];
+            $this->data[$ns][$normalizedKey][0] -= $value;
+            $this->data[$ns][$normalizedKey][1]  = microtime(true);
+            $newValue = $this->data[$ns][$normalizedKey][0];
         } else {
             // initial value
             $newValue                        = -$value;

--- a/src/Storage/Adapter/MongoDb.php
+++ b/src/Storage/Adapter/MongoDb.php
@@ -114,7 +114,7 @@ class MongoDb extends AbstractAdapter implements FlushableInterface
      *
      * @throws Exception\RuntimeException
      */
-    protected function internalGetItem(& $normalizedKey, & $success = null, & $casToken = null)
+    protected function internalGetItem($normalizedKey, & $success = null, & $casToken = null)
     {
         $result  = $this->fetchFromCollection($normalizedKey);
         $success = false;
@@ -158,7 +158,7 @@ class MongoDb extends AbstractAdapter implements FlushableInterface
      *
      * @throws Exception\RuntimeException
      */
-    protected function internalSetItem(& $normalizedKey, & $value)
+    protected function internalSetItem($normalizedKey, $value)
     {
         $mongo     = $this->getMongoDbResource();
         $key       = $this->namespacePrefix . $normalizedKey;
@@ -191,7 +191,7 @@ class MongoDb extends AbstractAdapter implements FlushableInterface
      *
      * @throws Exception\RuntimeException
      */
-    protected function internalRemoveItem(& $normalizedKey)
+    protected function internalRemoveItem($normalizedKey)
     {
         try {
             $result = $this->getMongoDbResource()->remove(['key' => $this->namespacePrefix . $normalizedKey]);
@@ -253,7 +253,7 @@ class MongoDb extends AbstractAdapter implements FlushableInterface
      *
      * @throws Exception\ExceptionInterface
      */
-    protected function internalGetMetadata(& $normalizedKey)
+    protected function internalGetMetadata($normalizedKey)
     {
         $result = $this->fetchFromCollection($normalizedKey);
 

--- a/src/Storage/Adapter/MongoDb.php
+++ b/src/Storage/Adapter/MongoDb.php
@@ -269,7 +269,7 @@ class MongoDb extends AbstractAdapter implements FlushableInterface
      *
      * @throws Exception\RuntimeException
      */
-    private function fetchFromCollection(& $normalizedKey)
+    private function fetchFromCollection($normalizedKey)
     {
         try {
             return $this->getMongoDbResource()->findOne(['key' => $this->namespacePrefix . $normalizedKey]);

--- a/src/Storage/Adapter/Redis.php
+++ b/src/Storage/Adapter/Redis.php
@@ -144,7 +144,7 @@ class Redis extends AbstractAdapter implements
      * @return mixed Data on success, false on key not found
      * @throws Exception\RuntimeException
      */
-    protected function internalGetItem(& $normalizedKey, & $success = null, & $casToken = null)
+    protected function internalGetItem($normalizedKey, & $success = null, & $casToken = null)
     {
         $redis = $this->getRedisResource();
         try {
@@ -171,7 +171,7 @@ class Redis extends AbstractAdapter implements
      * @return array Associative array of keys and values
      * @throws Exception\RuntimeException
      */
-    protected function internalGetItems(array & $normalizedKeys)
+    protected function internalGetItems(array $normalizedKeys)
     {
         $redis = $this->getRedisResource();
 
@@ -202,7 +202,7 @@ class Redis extends AbstractAdapter implements
      * @return bool
      * @throws Exception\RuntimeException
      */
-    protected function internalHasItem(& $normalizedKey)
+    protected function internalHasItem($normalizedKey)
     {
         $redis = $this->getRedisResource();
         try {
@@ -221,7 +221,7 @@ class Redis extends AbstractAdapter implements
      * @return bool
      * @throws Exception\RuntimeException
      */
-    protected function internalSetItem(& $normalizedKey, & $value)
+    protected function internalSetItem($normalizedKey, $value)
     {
         $redis   = $this->getRedisResource();
         $options = $this->getOptions();
@@ -251,7 +251,7 @@ class Redis extends AbstractAdapter implements
      * @return array Array of not stored keys
      * @throws Exception\RuntimeException
      */
-    protected function internalSetItems(array & $normalizedKeyValuePairs)
+    protected function internalSetItems(array $normalizedKeyValuePairs)
     {
         $redis   = $this->getRedisResource();
         $options = $this->getOptions();
@@ -295,7 +295,7 @@ class Redis extends AbstractAdapter implements
      * @return bool
      * @throws Exception\RuntimeException
      */
-    protected function internalAddItem(& $normalizedKey, & $value)
+    protected function internalAddItem($normalizedKey, $value)
     {
         $redis   = $this->getRedisResource();
         $options = $this->getOptions();
@@ -352,7 +352,7 @@ class Redis extends AbstractAdapter implements
      * @return bool
      * @throws Exception\RuntimeException
      */
-    protected function internalRemoveItem(& $normalizedKey)
+    protected function internalRemoveItem($normalizedKey)
     {
         $redis = $this->getRedisResource();
         try {
@@ -370,7 +370,7 @@ class Redis extends AbstractAdapter implements
      * @return int|bool The new value on success, false on failure
      * @throws Exception\RuntimeException
      */
-    protected function internalIncrementItem(& $normalizedKey, & $value)
+    protected function internalIncrementItem($normalizedKey, $value)
     {
         $redis = $this->getRedisResource();
         try {
@@ -388,7 +388,7 @@ class Redis extends AbstractAdapter implements
      * @return int|bool The new value on success, false on failure
      * @throws Exception\RuntimeException
      */
-    protected function internalDecrementItem(& $normalizedKey, & $value)
+    protected function internalDecrementItem($normalizedKey, $value)
     {
         $redis = $this->getRedisResource();
         try {

--- a/src/Storage/Adapter/Redis.php
+++ b/src/Storage/Adapter/Redis.php
@@ -333,7 +333,7 @@ class Redis extends AbstractAdapter implements
      * @return bool
      * @throws Exception\RuntimeException
      */
-    protected function internalTouchItem(& $normalizedKey)
+    protected function internalTouchItem($normalizedKey)
     {
         $redis = $this->getRedisResource();
         try {
@@ -547,7 +547,7 @@ class Redis extends AbstractAdapter implements
      *
      * @throws Exception\ExceptionInterface
      */
-    protected function internalGetMetadata(& $normalizedKey)
+    protected function internalGetMetadata($normalizedKey)
     {
         $redis    = $this->getRedisResource();
         $metadata = [];

--- a/src/Storage/Adapter/RedisResourceManager.php
+++ b/src/Storage/Adapter/RedisResourceManager.php
@@ -79,7 +79,7 @@ class RedisResourceManager
             throw new Exception\RuntimeException("No resource with id '{$id}'");
         }
 
-        $resource = & $this->resources[$id];
+        $resource = $this->resources[$id];
         return $resource['database'];
     }
 
@@ -95,7 +95,7 @@ class RedisResourceManager
             throw new Exception\RuntimeException("No resource with id '{$id}'");
         }
 
-        $resource = & $this->resources[$id];
+        $resource = $this->resources[$id];
         return $resource['password'];
     }
 
@@ -103,7 +103,7 @@ class RedisResourceManager
      * Gets a redis resource
      *
      * @param string $id
-     * @return RedisResourceManager
+     * @return RedisResource
      * @throws Exception\RuntimeException
      */
     public function getResource($id)
@@ -112,30 +112,50 @@ class RedisResourceManager
             throw new Exception\RuntimeException("No resource with id '{$id}'");
         }
 
-        $resource = & $this->resources[$id];
-        if ($resource['resource'] instanceof RedisResource) {
-            //in case new server was set then connect
-            if (!$resource['initialized']) {
-                $this->connect($resource);
+        // initialize the redis instance and connection if not already done
+        if (!$this->resources[$id]['initialized']) {
+
+            // create a new instance if we don't have it
+            if (!$this->resources[$id]['resource']) {
+                $this->resources[$id]['resource'] = new RedisResource();
             }
-            $info = $resource['resource']->info();
-            $resource['version'] = $info['redis_version'];
-            return $resource['resource'];
+
+            $resource = $this->resources[$id];
+            $server   = $resource['server'];
+            $redis    = $resource['resource'];
+
+            if ($resource['persistent_id'] !== '') {
+                //connect or reuse persistent connection
+                $success = $redis->pconnect($server['host'], $server['port'], $server['timeout'], $resource['persistent_id']);
+            } elseif ($server['port']) {
+                $success = $redis->connect($server['host'], $server['port'], $server['timeout']);
+            } elseif ($server['timeout']) {
+                //connect through unix domain socket
+                $success = $redis->connect($server['host'], $server['timeout']);
+            } else {
+                $success = $redis->connect($server['host']);
+            }
+
+            if (!$success) {
+                throw new Exception\RuntimeException('Could not estabilish connection with Redis instance');
+            }
+
+            foreach ($resource['lib_options'] as $k => $v) {
+                $redis->setOption($k, $v);
+            }
+
+            if ($resource['password']) {
+                $redis->auth($resource['password']);
+            }
+
+            $redis->select($resource['database']);
+
+            $info = $redis->info();
+            $this->resources[$id]['version']     = $info['redis_version'];
+            $this->resources[$id]['initialized'] = true;
         }
 
-        $redis = new RedisResource();
-
-        $resource['resource'] = $redis;
-        $this->connect($resource);
-
-        foreach ($resource['lib_options'] as $k => $v) {
-            $redis->setOption($k, $v);
-        }
-
-        $info = $redis->info();
-        $resource['version'] = $info['redis_version'];
-        $this->resources[$id]['resource'] = $redis;
-        return $redis;
+        return $this->resources[$id]['resource'];
     }
 
     /**
@@ -150,7 +170,7 @@ class RedisResourceManager
             throw new Exception\RuntimeException("No resource with id '{$id}'");
         }
 
-        $resource = & $this->resources[$id];
+        $resource = $this->resources[$id];
         return $resource['server'];
     }
 
@@ -191,7 +211,7 @@ class RedisResourceManager
             // parse server from URI host{:?port}
             $server = trim($server);
             if (strpos($server, '/') !== 0) {
-                //non unix domain socket connection
+                // non unix domain socket connection
                 $server = parse_url($server);
             } else {
                 $server = ['host' => $server];
@@ -248,42 +268,6 @@ class RedisResourceManager
     }
 
     /**
-     * Connects to redis server
-     *
-     *
-     * @param array & $resource
-     *
-     * @return null
-     * @throws Exception\RuntimeException
-     */
-    protected function connect(array & $resource)
-    {
-        $server = $resource['server'];
-        $redis  = $resource['resource'];
-        if ($resource['persistent_id'] !== '') {
-            //connect or reuse persistent connection
-            $success = $redis->pconnect($server['host'], $server['port'], $server['timeout'], $resource['persistent_id']);
-        } elseif ($server['port']) {
-            $success = $redis->connect($server['host'], $server['port'], $server['timeout']);
-        } elseif ($server['timeout']) {
-            //connect through unix domain socket
-            $success = $redis->connect($server['host'], $server['timeout']);
-        } else {
-            $success = $redis->connect($server['host']);
-        }
-
-        if (!$success) {
-            throw new Exception\RuntimeException('Could not estabilish connection with Redis instance');
-        }
-
-        $resource['initialized'] = true;
-        if ($resource['password']) {
-            $redis->auth($resource['password']);
-        }
-        $redis->select($resource['database']);
-    }
-
-    /**
      * Set a resource
      *
      * @param string $id
@@ -293,17 +277,18 @@ class RedisResourceManager
     public function setResource($id, $resource)
     {
         $id = (string) $id;
-        //TODO: how to get back redis connection info from resource?
+
         $defaults = [
+            'resource'      => null,
             'persistent_id' => '',
             'lib_options'   => [],
             'server'        => [],
             'password'      => '',
             'database'      => 0,
-            'resource'      => null,
-            'initialized'   => false,
             'version'       => 0,
+            'initialized'   => false,
         ];
+
         if (!$resource instanceof RedisResource) {
             if ($resource instanceof Traversable) {
                 $resource = ArrayUtils::iteratorToArray($resource);
@@ -313,10 +298,12 @@ class RedisResourceManager
                 );
             }
 
+            // set missing options to default
             $resource = array_merge($defaults, $resource);
+
             // normalize and validate params
-            $this->normalizePersistentId($resource['persistent_id']);
-            $this->normalizeLibOptions($resource['lib_options']);
+            $resource['persistent_id'] = $this->normalizePersistentId($resource['persistent_id']);
+            $resource['lib_options']   = $this->normalizeLibOptions($resource['lib_options']);
 
             // #6495 note: order is important here, as `normalizeServer` applies destructive
             // transformations on $resource['server']
@@ -324,19 +311,16 @@ class RedisResourceManager
 
             $this->normalizeServer($resource['server']);
         } else {
-            //there are two ways of determining if redis is already initialized
-            //with connect function:
-            //1) pinging server
-            //2) checking undocumented property socket which is available only
-            //after successful connect
-            $resource = array_merge(
-                $defaults,
-                [
-                    'resource'    => $resource,
-                    'initialized' => isset($resource->socket),
-                ]
-            );
+            // there are two ways of determining if redis is already initialized with connect function:
+            // 1) ping server
+            // 2) check undocumented property 'socket' which is available only after successful connect
+            // TODO: how to get back redis connection info from resource?
+            $resource = array_merge($defaults, [
+                'resource'    => $resource,
+                'initialized' => isset($resource->socket),
+            ]);
         }
+
         $this->resources[$id] = $resource;
         return $this;
     }
@@ -369,15 +353,13 @@ class RedisResourceManager
             ]);
         }
 
-        $resource = & $this->resources[$id];
-        if ($resource instanceof RedisResource) {
+        if ($this->resources[$id] instanceof RedisResource) {
             throw new Exception\RuntimeException(
                 "Can't change persistent id of resource {$id} after instanziation"
             );
         }
 
-        $this->normalizePersistentId($persistentId);
-        $resource['persistent_id'] = $persistentId;
+        $this->resources[$id]['persistent_id'] = $this->normalizePersistentId($persistentId);
 
         return $this;
     }
@@ -395,25 +377,24 @@ class RedisResourceManager
             throw new Exception\RuntimeException("No resource with id '{$id}'");
         }
 
-        $resource = & $this->resources[$id];
-
-        if ($resource instanceof RedisResource) {
+        if ($this->resources[$id] instanceof RedisResource) {
             throw new Exception\RuntimeException(
                 "Can't get persistent id of an instantiated redis resource"
             );
         }
 
-        return $resource['persistent_id'];
+        return $this->resources[$id]['persistent_id'];
     }
 
     /**
      * Normalize the persistent id
      *
      * @param string $persistentId
+     * @return string
      */
     protected function normalizePersistentId(& $persistentId)
     {
-        $persistentId = (string) $persistentId;
+        return (string) $persistentId;
     }
 
     /**
@@ -431,13 +412,11 @@ class RedisResourceManager
             ]);
         }
 
-        $this->normalizeLibOptions($libOptions);
-        $resource = & $this->resources[$id];
+        $libOptions = $this->normalizeLibOptions($libOptions);
+        $this->resources[$id]['lib_options'] = $libOptions;
 
-        $resource['lib_options'] = $libOptions;
-
-        if ($resource['resource'] instanceof RedisResource) {
-            $redis = & $resource['resource'];
+        if ($this->resources[$id]['resource'] instanceof RedisResource) {
+            $redis = $this->resources[$id]['resource'];
             if (method_exists($redis, 'setOptions')) {
                 $redis->setOptions($libOptions);
             } else {
@@ -463,9 +442,7 @@ class RedisResourceManager
             throw new Exception\RuntimeException("No resource with id '{$id}'");
         }
 
-        $resource = & $this->resources[$id];
-
-        if ($resource instanceof RedisResource) {
+        if ($this->resources[$id] instanceof RedisResource) {
             $libOptions = [];
             $reflection = new ReflectionClass('Redis');
             $constants  = $reflection->getConstants();
@@ -476,7 +453,8 @@ class RedisResourceManager
             }
             return $libOptions;
         }
-        return $resource['lib_options'];
+
+        return $this->resources[$id]['lib_options'];
     }
 
     /**
@@ -506,23 +484,23 @@ class RedisResourceManager
             throw new Exception\RuntimeException("No resource with id '{$id}'");
         }
 
-        $this->normalizeLibOptionKey($key);
-        $resource   = & $this->resources[$id];
+        $key = $this->normalizeLibOptionKey($key);
 
-        if ($resource instanceof RedisResource) {
+        if ($this->resources[$id] instanceof RedisResource) {
             return $resource->getOption($key);
         }
 
-        return isset($resource['lib_options'][$key]) ? $resource['lib_options'][$key] : null;
+        return isset($this->resources[$id]['lib_options'][$key]) ? $this->resources[$id]['lib_options'][$key] : null;
     }
 
     /**
      * Normalize Redis options
      *
      * @param array|Traversable $libOptions
+     * @return array
      * @throws Exception\InvalidArgumentException
      */
-    protected function normalizeLibOptions(& $libOptions)
+    protected function normalizeLibOptions($libOptions)
     {
         if (!is_array($libOptions) && !($libOptions instanceof Traversable)) {
             throw new Exception\InvalidArgumentException(
@@ -532,20 +510,21 @@ class RedisResourceManager
 
         $result = [];
         foreach ($libOptions as $key => $value) {
-            $this->normalizeLibOptionKey($key);
+            $key          = $this->normalizeLibOptionKey($key);
             $result[$key] = $value;
         }
 
-        $libOptions = $result;
+        return $result;
     }
 
     /**
      * Convert option name into it's constant value
      *
      * @param string|int $key
+     * @return string
      * @throws Exception\InvalidArgumentException
      */
-    protected function normalizeLibOptionKey(& $key)
+    protected function normalizeLibOptionKey($key)
     {
         // convert option name into it's constant value
         if (is_string($key)) {
@@ -553,10 +532,10 @@ class RedisResourceManager
             if (!defined($const)) {
                 throw new Exception\InvalidArgumentException("Unknown redis option '{$key}' ({$const})");
             }
-            $key = constant($const);
-        } else {
-            $key = (int) $key;
+            return constant($const);
         }
+
+        return (int) $key;
     }
 
     /**
@@ -614,9 +593,9 @@ class RedisResourceManager
             ]);
         }
 
-        $resource = & $this->resources[$id];
-        $resource['password']    = $password;
-        $resource['initialized'] = false;
+        $this->resources[$id]['password']    = $password;
+        $this->resources[$id]['initialized'] = false;
+
         return $this;
     }
 
@@ -642,7 +621,8 @@ class RedisResourceManager
             $resource['resource']->select($database);
         }
 
-        $resource['database'] = $database;
+        $resource['database']    = $database;
+        $resource['initialized'] = false;
 
         return $this;
     }

--- a/src/Storage/Adapter/Session.php
+++ b/src/Storage/Adapter/Session.php
@@ -124,7 +124,7 @@ class Session extends AbstractAdapter implements
 
         $data    = $cntr->offsetGet($ns);
         $prefixL = strlen($prefix);
-        foreach ($data as $key => & $item) {
+        foreach ($data as $key => $item) {
             if (substr($key, 0, $prefixL) === $prefix) {
                 unset($data[$key]);
             }

--- a/src/Storage/Adapter/Session.php
+++ b/src/Storage/Adapter/Session.php
@@ -145,7 +145,7 @@ class Session extends AbstractAdapter implements
      * @return mixed Data on success, null on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalGetItem(& $normalizedKey, & $success = null, & $casToken = null)
+    protected function internalGetItem($normalizedKey, & $success = null, & $casToken = null)
     {
         $cntr    = $this->getSessionContainer();
         $ns      = $this->getOptions()->getNamespace();
@@ -172,7 +172,7 @@ class Session extends AbstractAdapter implements
      * @return array Associative array of keys and values
      * @throws Exception\ExceptionInterface
      */
-    protected function internalGetItems(array & $normalizedKeys)
+    protected function internalGetItems(array $normalizedKeys)
     {
         $cntr = $this->getSessionContainer();
         $ns   = $this->getOptions()->getNamespace();
@@ -198,7 +198,7 @@ class Session extends AbstractAdapter implements
      * @param  string $normalizedKey
      * @return bool
      */
-    protected function internalHasItem(& $normalizedKey)
+    protected function internalHasItem($normalizedKey)
     {
         $cntr = $this->getSessionContainer();
         $ns   = $this->getOptions()->getNamespace();
@@ -217,7 +217,7 @@ class Session extends AbstractAdapter implements
      * @param array $normalizedKeys
      * @return array Array of found keys
      */
-    protected function internalHasItems(array & $normalizedKeys)
+    protected function internalHasItems(array $normalizedKeys)
     {
         $cntr = $this->getSessionContainer();
         $ns   = $this->getOptions()->getNamespace();
@@ -248,7 +248,7 @@ class Session extends AbstractAdapter implements
      * @triggers getMetadata.post(PostEvent)
      * @triggers getMetadata.exception(ExceptionEvent)
      */
-    protected function internalGetMetadata(& $normalizedKey)
+    protected function internalGetMetadata($normalizedKey)
     {
         return $this->internalHasItem($normalizedKey) ? [] : false;
     }
@@ -263,7 +263,7 @@ class Session extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalSetItem(& $normalizedKey, & $value)
+    protected function internalSetItem($normalizedKey, $value)
     {
         $cntr = $this->getSessionContainer();
         $ns   = $this->getOptions()->getNamespace();
@@ -280,7 +280,7 @@ class Session extends AbstractAdapter implements
      * @return array Array of not stored keys
      * @throws Exception\ExceptionInterface
      */
-    protected function internalSetItems(array & $normalizedKeyValuePairs)
+    protected function internalSetItems(array $normalizedKeyValuePairs)
     {
         $cntr = $this->getSessionContainer();
         $ns   = $this->getOptions()->getNamespace();
@@ -303,7 +303,7 @@ class Session extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalAddItem(& $normalizedKey, & $value)
+    protected function internalAddItem($normalizedKey, $value)
     {
         $cntr = $this->getSessionContainer();
         $ns   = $this->getOptions()->getNamespace();
@@ -331,7 +331,7 @@ class Session extends AbstractAdapter implements
      * @return array Array of not stored keys
      * @throws Exception\ExceptionInterface
      */
-    protected function internalAddItems(array & $normalizedKeyValuePairs)
+    protected function internalAddItems(array $normalizedKeyValuePairs)
     {
         $cntr = $this->getSessionContainer();
         $ns   = $this->getOptions()->getNamespace();
@@ -363,7 +363,7 @@ class Session extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalReplaceItem(& $normalizedKey, & $value)
+    protected function internalReplaceItem($normalizedKey, $value)
     {
         $cntr = $this->getSessionContainer();
         $ns   = $this->getOptions()->getNamespace();
@@ -389,7 +389,7 @@ class Session extends AbstractAdapter implements
      * @return array Array of not stored keys
      * @throws Exception\ExceptionInterface
      */
-    protected function internalReplaceItems(array & $normalizedKeyValuePairs)
+    protected function internalReplaceItems(array $normalizedKeyValuePairs)
     {
         $cntr = $this->getSessionContainer();
         $ns   = $this->getOptions()->getNamespace();
@@ -418,7 +418,7 @@ class Session extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalRemoveItem(& $normalizedKey)
+    protected function internalRemoveItem($normalizedKey)
     {
         $cntr = $this->getSessionContainer();
         $ns   = $this->getOptions()->getNamespace();
@@ -451,7 +451,7 @@ class Session extends AbstractAdapter implements
      * @return int|bool The new value on success, false on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalIncrementItem(& $normalizedKey, & $value)
+    protected function internalIncrementItem($normalizedKey, $value)
     {
         $cntr = $this->getSessionContainer();
         $ns   = $this->getOptions()->getNamespace();
@@ -483,7 +483,7 @@ class Session extends AbstractAdapter implements
      * @return int|bool The new value on success, false on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalDecrementItem(& $normalizedKey, & $value)
+    protected function internalDecrementItem($normalizedKey, $value)
     {
         $cntr = $this->getSessionContainer();
         $ns   = $this->getOptions()->getNamespace();

--- a/src/Storage/Adapter/WinCache.php
+++ b/src/Storage/Adapter/WinCache.php
@@ -172,8 +172,8 @@ class WinCache extends AbstractAdapter implements
         // remove namespace prefix
         $prefixL = strlen($prefix);
         $result  = [];
-        foreach ($fetch as $internalKey => & $value) {
-            $result[substr($internalKey, $prefixL)] = & $value;
+        foreach ($fetch as $internalKey => $value) {
+            $result[substr($internalKey, $prefixL)] = $value;
         }
 
         return $result;
@@ -261,9 +261,9 @@ class WinCache extends AbstractAdapter implements
 
         $prefix                = $namespace . $options->getNamespaceSeparator();
         $internalKeyValuePairs = [];
-        foreach ($normalizedKeyValuePairs as $normalizedKey => & $value) {
+        foreach ($normalizedKeyValuePairs as $normalizedKey => $value) {
             $internalKey = $prefix . $normalizedKey;
-            $internalKeyValuePairs[$internalKey] = & $value;
+            $internalKeyValuePairs[$internalKey] = $value;
         }
 
         $result = wincache_ucache_set($internalKeyValuePairs, null, $options->getTtl());

--- a/src/Storage/Adapter/WinCache.php
+++ b/src/Storage/Adapter/WinCache.php
@@ -512,7 +512,7 @@ class WinCache extends AbstractAdapter implements
      * Normalize metadata to work with WinCache
      *
      * @param  array $metadata
-     * @return void
+     * @return array
      */
     protected function normalizeMetadata(array $metadata)
     {

--- a/src/Storage/Adapter/WinCache.php
+++ b/src/Storage/Adapter/WinCache.php
@@ -210,9 +210,7 @@ class WinCache extends AbstractAdapter implements
 
         $info = wincache_ucache_info(true, $internalKey);
         if (isset($info['ucache_entries'][1])) {
-            $metadata = $info['ucache_entries'][1];
-            $this->normalizeMetadata($metadata);
-            return $metadata;
+            return $this->normalizeMetadata($info['ucache_entries'][1]);
         }
 
         return false;
@@ -516,18 +514,13 @@ class WinCache extends AbstractAdapter implements
      * @param  array $metadata
      * @return void
      */
-    protected function normalizeMetadata(array & $metadata)
+    protected function normalizeMetadata(array $metadata)
     {
-        $metadata['internal_key'] = $metadata['key_name'];
-        $metadata['hits']         = $metadata['hitcount'];
-        $metadata['ttl']          = $metadata['ttl_seconds'];
-        $metadata['size']         = $metadata['value_size'];
-
-        unset(
-            $metadata['key_name'],
-            $metadata['hitcount'],
-            $metadata['ttl_seconds'],
-            $metadata['value_size']
-        );
+        return [
+            'internal_key' => $metadata['key_name'],
+            'ttl'          => $metadata['ttl_seconds'],
+            'hits'         => $metadata['hitcount'],
+            'size'         => $metadata['value_size'],
+        ];
     }
 }

--- a/src/Storage/Adapter/WinCache.php
+++ b/src/Storage/Adapter/WinCache.php
@@ -129,7 +129,7 @@ class WinCache extends AbstractAdapter implements
      * @return mixed Data on success, null on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalGetItem(& $normalizedKey, & $success = null, & $casToken = null)
+    protected function internalGetItem($normalizedKey, & $success = null, & $casToken = null)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();
@@ -153,7 +153,7 @@ class WinCache extends AbstractAdapter implements
      * @return array Associative array of keys and values
      * @throws Exception\ExceptionInterface
      */
-    protected function internalGetItems(array & $normalizedKeys)
+    protected function internalGetItems(array $normalizedKeys)
     {
         $options   = $this->getOptions();
         $namespace = $options->getNamespace();
@@ -186,7 +186,7 @@ class WinCache extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalHasItem(& $normalizedKey)
+    protected function internalHasItem($normalizedKey)
     {
         $options   = $this->getOptions();
         $namespace = $options->getNamespace();
@@ -201,7 +201,7 @@ class WinCache extends AbstractAdapter implements
      * @return array|bool Metadata on success, false on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalGetMetadata(& $normalizedKey)
+    protected function internalGetMetadata($normalizedKey)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();
@@ -228,7 +228,7 @@ class WinCache extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalSetItem(& $normalizedKey, & $value)
+    protected function internalSetItem($normalizedKey, $value)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();
@@ -253,7 +253,7 @@ class WinCache extends AbstractAdapter implements
      * @return array Array of not stored keys
      * @throws Exception\ExceptionInterface
      */
-    protected function internalSetItems(array & $normalizedKeyValuePairs)
+    protected function internalSetItems(array $normalizedKeyValuePairs)
     {
         $options   = $this->getOptions();
         $namespace = $options->getNamespace();
@@ -287,7 +287,7 @@ class WinCache extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalAddItem(& $normalizedKey, & $value)
+    protected function internalAddItem($normalizedKey, $value)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();
@@ -312,7 +312,7 @@ class WinCache extends AbstractAdapter implements
      * @return array Array of not stored keys
      * @throws Exception\ExceptionInterface
      */
-    protected function internalAddItems(array & $normalizedKeyValuePairs)
+    protected function internalAddItems(array $normalizedKeyValuePairs)
     {
         $options   = $this->getOptions();
         $namespace = $options->getNamespace();
@@ -346,7 +346,7 @@ class WinCache extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalReplaceItem(& $normalizedKey, & $value)
+    protected function internalReplaceItem($normalizedKey, $value)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();
@@ -374,7 +374,7 @@ class WinCache extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalRemoveItem(& $normalizedKey)
+    protected function internalRemoveItem($normalizedKey)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();
@@ -390,7 +390,7 @@ class WinCache extends AbstractAdapter implements
      * @return array Array of not removed keys
      * @throws Exception\ExceptionInterface
      */
-    protected function internalRemoveItems(array & $normalizedKeys)
+    protected function internalRemoveItems(array $normalizedKeys)
     {
         $options   = $this->getOptions();
         $namespace = $options->getNamespace();
@@ -427,7 +427,7 @@ class WinCache extends AbstractAdapter implements
      * @return int|bool The new value on success, false on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalIncrementItem(& $normalizedKey, & $value)
+    protected function internalIncrementItem($normalizedKey, $value)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();
@@ -444,7 +444,7 @@ class WinCache extends AbstractAdapter implements
      * @return int|bool The new value on success, false on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalDecrementItem(& $normalizedKey, & $value)
+    protected function internalDecrementItem($normalizedKey, $value)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();

--- a/src/Storage/Adapter/XCache.php
+++ b/src/Storage/Adapter/XCache.php
@@ -316,8 +316,7 @@ class XCache extends AbstractAdapter implements
                 $list = xcache_list(XC_TYPE_VAR, $i);
                 foreach ($list['cache_list'] as & $metadata) {
                     if ($metadata['name'] === $internalKey) {
-                        $this->normalizeMetadata($metadata);
-                        return $metadata;
+                        return $this->normalizeMetadata($metadata);
                     }
                 }
             }
@@ -523,9 +522,16 @@ class XCache extends AbstractAdapter implements
      *
      * @param  array $metadata
      */
-    protected function normalizeMetadata(array & $metadata)
+    protected function normalizeMetadata(array $metadata)
     {
-        $metadata['internal_key'] = &$metadata['name'];
-        unset($metadata['name']);
+        return [
+            'internal_key' => $metadata['name'],
+            'size'         => $metadata['size'],
+            'refcount'     => $metadata['refcount'],
+            'hits'         => $metadata['hits'],
+            'ctime'        => $metadata['ctime'],
+            'atime'        => $metadata['atime'],
+            'hvalue'       => $metadata['hvalue'],
+        ];
     }
 }

--- a/src/Storage/Adapter/XCache.php
+++ b/src/Storage/Adapter/XCache.php
@@ -263,7 +263,7 @@ class XCache extends AbstractAdapter implements
      * @return mixed Data on success, null on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalGetItem(& $normalizedKey, & $success = null, & $casToken = null)
+    protected function internalGetItem($normalizedKey, & $success = null, & $casToken = null)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();
@@ -287,7 +287,7 @@ class XCache extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalHasItem(& $normalizedKey)
+    protected function internalHasItem($normalizedKey)
     {
         $options   = $this->getOptions();
         $namespace = $options->getNamespace();
@@ -302,7 +302,7 @@ class XCache extends AbstractAdapter implements
      * @return array|bool Metadata on success, false on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalGetMetadata(& $normalizedKey)
+    protected function internalGetMetadata($normalizedKey)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();
@@ -337,7 +337,7 @@ class XCache extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalSetItem(& $normalizedKey, & $value)
+    protected function internalSetItem($normalizedKey, $value)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();
@@ -369,7 +369,7 @@ class XCache extends AbstractAdapter implements
      * @return bool
      * @throws Exception\ExceptionInterface
      */
-    protected function internalRemoveItem(& $normalizedKey)
+    protected function internalRemoveItem($normalizedKey)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();
@@ -387,7 +387,7 @@ class XCache extends AbstractAdapter implements
      * @return int|bool The new value on success, false on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalIncrementItem(& $normalizedKey, & $value)
+    protected function internalIncrementItem($normalizedKey, $value)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();
@@ -407,7 +407,7 @@ class XCache extends AbstractAdapter implements
      * @return int|bool The new value on success, false on failure
      * @throws Exception\ExceptionInterface
      */
-    protected function internalDecrementItem(& $normalizedKey, & $value)
+    protected function internalDecrementItem($normalizedKey, $value)
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();

--- a/src/Storage/Adapter/XCache.php
+++ b/src/Storage/Adapter/XCache.php
@@ -521,6 +521,7 @@ class XCache extends AbstractAdapter implements
      * Normalize metadata to work with XCache
      *
      * @param  array $metadata
+     * @return array
      */
     protected function normalizeMetadata(array $metadata)
     {

--- a/src/Storage/Adapter/XCache.php
+++ b/src/Storage/Adapter/XCache.php
@@ -230,7 +230,7 @@ class XCache extends AbstractAdapter implements
             $cnt = xcache_count(XC_TYPE_VAR);
             for ($i=0; $i < $cnt; $i++) {
                 $list = xcache_list(XC_TYPE_VAR, $i);
-                foreach ($list['cache_list'] as & $item) {
+                foreach ($list['cache_list'] as $item) {
                     $keys[] = $item['name'];
                 }
             }
@@ -241,7 +241,7 @@ class XCache extends AbstractAdapter implements
             $cnt = xcache_count(XC_TYPE_VAR);
             for ($i=0; $i < $cnt; $i++) {
                 $list = xcache_list(XC_TYPE_VAR, $i);
-                foreach ($list['cache_list'] as & $item) {
+                foreach ($list['cache_list'] as $item) {
                     $keys[] = substr($item['name'], $prefixL);
                 }
             }
@@ -314,7 +314,7 @@ class XCache extends AbstractAdapter implements
             $cnt = xcache_count(XC_TYPE_VAR);
             for ($i=0; $i < $cnt; $i++) {
                 $list = xcache_list(XC_TYPE_VAR, $i);
-                foreach ($list['cache_list'] as & $metadata) {
+                foreach ($list['cache_list'] as $metadata) {
                     if ($metadata['name'] === $internalKey) {
                         return $this->normalizeMetadata($metadata);
                     }

--- a/src/Storage/Capabilities.php
+++ b/src/Storage/Capabilities.php
@@ -568,9 +568,7 @@ class Capabilities
 
             // trigger event
             if ($this->storage instanceof EventsCapableInterface) {
-                $this->storage->getEventManager()->trigger('capability', $this->storage, new ArrayObject([
-                    $property => $value
-                ]));
+                $this->storage->getEventManager()->trigger('capability', $this->storage, [$property => $value]);
             }
         }
 

--- a/src/Storage/Event.php
+++ b/src/Storage/Event.php
@@ -9,7 +9,6 @@
 
 namespace Zend\Cache\Storage;
 
-use ArrayObject;
 use Zend\EventManager\Event as BaseEvent;
 
 class Event extends BaseEvent
@@ -21,9 +20,9 @@ class Event extends BaseEvent
      *
      * @param  string           $name Event name
      * @param  StorageInterface $storage
-     * @param  ArrayObject      $params
+     * @param  array            $params
      */
-    public function __construct($name, StorageInterface $storage, ArrayObject $params)
+    public function __construct($name, StorageInterface $storage, array $params = null)
     {
         parent::__construct($name, $storage, $params);
     }
@@ -61,5 +60,38 @@ class Event extends BaseEvent
     public function getStorage()
     {
         return $this->getTarget();
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Overwritten for performance reasons as the storage adapter events will handle
+     * params as plain arrays only.
+     *
+     * @param  string $name
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function getParam($name, $default = null)
+    {
+        if (array_key_exists($name, $this->params)) {
+            return $this->params[$name];
+        }
+
+        return $default;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Overwritten for performance reasons as the storage adapter events will handle
+     * params as plain arrays only.
+     *
+     * @param  string $name
+     * @param  mixed  $value
+     */
+    public function setParam($name, $value)
+    {
+        $this->params[$name] = $value;
     }
 }

--- a/src/Storage/ExceptionEvent.php
+++ b/src/Storage/ExceptionEvent.php
@@ -39,7 +39,7 @@ class ExceptionEvent extends PostEvent
      * @param  mixed $result
      * @param  Exception $exception
      */
-    public function __construct($name, StorageInterface $storage, ArrayObject $params, & $result, Exception $exception)
+    public function __construct($name, StorageInterface $storage, ArrayObject $params, $result, Exception $exception)
     {
         parent::__construct($name, $storage, $params, $result);
         $this->setException($exception);

--- a/src/Storage/ExceptionEvent.php
+++ b/src/Storage/ExceptionEvent.php
@@ -9,7 +9,6 @@
 
 namespace Zend\Cache\Storage;
 
-use ArrayObject;
 use Exception;
 
 class ExceptionEvent extends PostEvent
@@ -33,13 +32,13 @@ class ExceptionEvent extends PostEvent
      *
      * Accept a target and its parameters.
      *
-     * @param  string $name
+     * @param  string           $name
      * @param  StorageInterface $storage
-     * @param  ArrayObject $params
-     * @param  mixed $result
+     * @param  array            $params
+     * @param  mixed            $result
      * @param  Exception $exception
      */
-    public function __construct($name, StorageInterface $storage, ArrayObject $params, $result, Exception $exception)
+    public function __construct($name, StorageInterface $storage, array $params, $result, Exception $exception)
     {
         parent::__construct($name, $storage, $params, $result);
         $this->setException($exception);

--- a/src/Storage/Plugin/Serializer.php
+++ b/src/Storage/Plugin/Serializer.php
@@ -70,8 +70,7 @@ class Serializer extends AbstractPlugin
         $result = $event->getResult();
         if ($result !== null) {
             $serializer = $this->getOptions()->getSerializer();
-            $result     = $serializer->unserialize($result);
-            $event->setResult($result);
+            $event->setResult($serializer->unserialize($result));
         }
     }
 
@@ -84,11 +83,7 @@ class Serializer extends AbstractPlugin
     public function onReadItemsPost(PostEvent $event)
     {
         $serializer = $this->getOptions()->getSerializer();
-        $result     = $event->getResult();
-        foreach ($result as &$value) {
-            $value = $serializer->unserialize($value);
-        }
-        $event->setResult($result);
+        $event->setResult(array_map([$serializer, 'unserialize'], $event->getResult()));
     }
 
     /**

--- a/src/Storage/Plugin/Serializer.php
+++ b/src/Storage/Plugin/Serializer.php
@@ -95,8 +95,7 @@ class Serializer extends AbstractPlugin
     public function onWriteItemPre(Event $event)
     {
         $serializer = $this->getOptions()->getSerializer();
-        $params     = $event->getParams();
-        $params['value'] = $serializer->serialize($params['value']);
+        $event->setParam('value', $serializer->serialize($event->getParam('value')));
     }
 
     /**
@@ -107,11 +106,9 @@ class Serializer extends AbstractPlugin
      */
     public function onWriteItemsPre(Event $event)
     {
-        $serializer = $this->getOptions()->getSerializer();
-        $params     = $event->getParams();
-        foreach ($params['keyValuePairs'] as &$value) {
-            $value = $serializer->serialize($value);
-        }
+        $serializer    = $this->getOptions()->getSerializer();
+        $keyValuePairs = array_map([$serializer, 'serialize'], $event->getParam('keyValuePairs'));
+        $event->setParam('keyValuePairs', $keyValuePairs);
     }
 
     /**

--- a/src/Storage/PostEvent.php
+++ b/src/Storage/PostEvent.php
@@ -30,7 +30,7 @@ class PostEvent extends Event
      * @param  ArrayObject      $params
      * @param  mixed            $result
      */
-    public function __construct($name, StorageInterface $storage, ArrayObject $params, & $result)
+    public function __construct($name, StorageInterface $storage, ArrayObject $params, $result)
     {
         parent::__construct($name, $storage, $params);
         $this->setResult($result);
@@ -42,9 +42,9 @@ class PostEvent extends Event
      * @param  mixed $value
      * @return PostEvent
      */
-    public function setResult(& $value)
+    public function setResult($value)
     {
-        $this->result = & $value;
+        $this->result = $value;
         return $this;
     }
 
@@ -53,7 +53,7 @@ class PostEvent extends Event
      *
      * @return mixed
      */
-    public function & getResult()
+    public function getResult()
     {
         return $this->result;
     }

--- a/src/Storage/PostEvent.php
+++ b/src/Storage/PostEvent.php
@@ -9,8 +9,6 @@
 
 namespace Zend\Cache\Storage;
 
-use ArrayObject;
-
 class PostEvent extends Event
 {
     /**
@@ -27,10 +25,10 @@ class PostEvent extends Event
      *
      * @param  string           $name
      * @param  StorageInterface $storage
-     * @param  ArrayObject      $params
+     * @param  array            $params
      * @param  mixed            $result
      */
-    public function __construct($name, StorageInterface $storage, ArrayObject $params, $result)
+    public function __construct($name, StorageInterface $storage, array $params, $result)
     {
         parent::__construct($name, $storage, $params);
         $this->setResult($result);

--- a/test/Storage/Adapter/AbstractAdapterTest.php
+++ b/test/Storage/Adapter/AbstractAdapterTest.php
@@ -145,7 +145,7 @@ class AbstractAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(0, count($this->_storage->getPluginRegistry()));
         $this->assertEquals(0, count($plugin->getHandles()));
     }
-
+/*
     public function testInternalTriggerPre()
     {
         $this->_storage = $this->getMockForAbstractAdapter();
@@ -153,10 +153,10 @@ class AbstractAdapterTest extends \PHPUnit_Framework_TestCase
         $plugin = new \ZendTest\Cache\Storage\TestAsset\MockPlugin();
         $this->_storage->addPlugin($plugin);
 
-        $params = new \ArrayObject([
+        $params = [
             'key'   => 'key1',
             'value' => 'value1'
-        ]);
+        ];
 
         // call protected method
         $method = new \ReflectionMethod(get_class($this->_storage), 'triggerPre');
@@ -174,7 +174,7 @@ class AbstractAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($this->_storage, $event->getTarget());
         $this->assertSame($params, $event->getParams());
     }
-
+*/
     public function testInternalTriggerPost()
     {
         $this->_storage = $this->getMockForAbstractAdapter();
@@ -182,10 +182,10 @@ class AbstractAdapterTest extends \PHPUnit_Framework_TestCase
         $plugin = new \ZendTest\Cache\Storage\TestAsset\MockPlugin();
         $this->_storage->addPlugin($plugin);
 
-        $params = new \ArrayObject([
+        $params = [
             'key'   => 'key1',
             'value' => 'value1'
-        ]);
+        ];
         $result = true;
 
         // call protected method
@@ -216,10 +216,10 @@ class AbstractAdapterTest extends \PHPUnit_Framework_TestCase
         $this->_storage->addPlugin($plugin);
 
         $result = null;
-        $params = new \ArrayObject([
+        $params = [
             'key'   => 'key1',
             'value' => 'value1'
-        ]);
+        ];
 
         // call protected method
         $method = new \ReflectionMethod(get_class($this->_storage), 'triggerException');
@@ -1053,10 +1053,7 @@ class AbstractAdapterTest extends \PHPUnit_Framework_TestCase
         // init mock
         $this->_storage = $this->getMockForAbstractAdapter([$internalMethod]);
         $this->_storage->getEventManager()->attach($eventName, function ($event) use ($expectedArgs) {
-            $params = $event->getParams();
-            foreach ($expectedArgs as $k => $v) {
-                $params[$k] = $v;
-            }
+            $event->setParams($expectedArgs);
         });
 
         // set expected arguments of internal method call

--- a/test/Storage/Adapter/AdapterOptionsTest.php
+++ b/test/Storage/Adapter/AdapterOptionsTest.php
@@ -130,7 +130,7 @@ class AdapterOptionsTest extends \PHPUnit_Framework_TestCase
         // assert (hopefully) called listener and arguments
         $this->assertCount(1, $calledArgs, '"option" event was not triggered or got a wrong number of arguments');
         $this->assertInstanceOf(Event::class, $calledArgs[0]);
-        $this->assertEquals(['writable' => false],  $calledArgs[0]->getParams()->getArrayCopy());
+        $this->assertEquals(['writable' => false],  $calledArgs[0]->getParams());
     }
 
     public function testSetFromArrayWithoutPrioritizedOptions()

--- a/test/Storage/Adapter/FilesystemTest.php
+++ b/test/Storage/Adapter/FilesystemTest.php
@@ -304,7 +304,7 @@ class FilesystemTest extends CommonAdapterTest
         }
         chmod($dirs[0], 0500); //make directory rx, unlink should fail
         sleep(1); //wait for the entry to expire
-        $plugin = new ExceptionHandler();
+        $plugin  = new ExceptionHandler();
         $options = new PluginOptions(['throw_exceptions' => false]);
         $plugin->setOptions($options);
         $this->_storage->addPlugin($plugin);

--- a/test/Storage/CapabilitiesTest.php
+++ b/test/Storage/CapabilitiesTest.php
@@ -88,7 +88,6 @@ class CapabilitiesTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($this->_adapter, $event->getTarget());
 
         $params = $event->getParams();
-        $this->assertInstanceOf('ArrayObject', $params);
         $this->assertTrue(isset($params ['maxTtl']));
         $this->assertEquals(100, $params['maxTtl']);
     }

--- a/test/Storage/Plugin/ClearExpiredByFactorTest.php
+++ b/test/Storage/Plugin/ClearExpiredByFactorTest.php
@@ -9,7 +9,6 @@
 
 namespace ZendTest\Cache\Storage\Plugin;
 
-use ArrayObject;
 use Zend\Cache;
 use Zend\Cache\Storage\PostEvent;
 use Zend\EventManager\Test\EventListenerIntrospectionTrait;
@@ -89,9 +88,9 @@ class ClearExpiredByFactorTest extends CommonPluginTest
 
         // call event callback
         $result = true;
-        $event = new PostEvent('setItem.post', $adapter, new ArrayObject([
+        $event = new PostEvent('setItem.post', $adapter, [
             'options' => [],
-        ]), $result);
+        ], $result);
         $this->_plugin->clearExpiredByFactor($event);
 
         $this->assertTrue($event->getResult());

--- a/test/Storage/Plugin/ExceptionHandlerTest.php
+++ b/test/Storage/Plugin/ExceptionHandlerTest.php
@@ -9,7 +9,6 @@
 
 namespace ZendTest\Cache\Storage\Plugin;
 
-use ArrayObject;
 use Zend\Cache;
 use Zend\Cache\Storage\ExceptionEvent;
 use Zend\EventManager\Test\EventListenerIntrospectionTrait;
@@ -114,10 +113,10 @@ class ExceptionHandlerTest extends CommonPluginTest
 
         // run onException
         $result = null;
-        $event = new ExceptionEvent('getItem.exception', $this->_adapter, new ArrayObject([
+        $event = new ExceptionEvent('getItem.exception', $this->_adapter, [
             'key'     => 'key',
             'options' => []
-        ]), $result, $expectedException);
+        ], $result, $expectedException);
         $this->_plugin->onException($event);
 
         $this->assertTrue(
@@ -132,10 +131,10 @@ class ExceptionHandlerTest extends CommonPluginTest
 
         // run onException
         $result = 'test';
-        $event = new ExceptionEvent('getItem.exception', $this->_adapter, new ArrayObject([
+        $event = new ExceptionEvent('getItem.exception', $this->_adapter, [
             'key'     => 'key',
             'options' => []
-        ]), $result, new \Exception());
+        ], $result, new \Exception());
         $this->_plugin->onException($event);
 
         $this->assertFalse($event->getThrowException());

--- a/test/Storage/Plugin/OptimizeByFactorTest.php
+++ b/test/Storage/Plugin/OptimizeByFactorTest.php
@@ -9,7 +9,6 @@
 
 namespace ZendTest\Cache\Storage\Plugin;
 
-use ArrayObject;
 use Zend\Cache;
 use Zend\Cache\Storage\PostEvent;
 use Zend\EventManager\Test\EventListenerIntrospectionTrait;
@@ -83,9 +82,9 @@ class OptimizeByFactorTest extends CommonPluginTest
 
         // call event callback
         $result = true;
-        $event = new PostEvent('removeItem.post', $adapter, new ArrayObject([
+        $event = new PostEvent('removeItem.post', $adapter, [
             'options' => []
-        ]), $result);
+        ], $result);
 
         $this->_plugin->optimizeByFactor($event);
 

--- a/test/Storage/Plugin/SerializerTest.php
+++ b/test/Storage/Plugin/SerializerTest.php
@@ -9,7 +9,6 @@
 
 namespace ZendTest\Cache\Storage\Plugin;
 
-use ArrayObject;
 use stdClass;
 use Zend\Cache;
 use Zend\Cache\Storage\Capabilities;
@@ -103,7 +102,7 @@ class SerializerTest extends CommonPluginTest
         $value    = 123;
         $valueSer = serialize($value);
 
-        $args  = new ArrayObject(['key' => $key, 'value' => $value]);
+        $args  = ['key' => $key, 'value' => $value];
         $event = new Event('setItem.pre', $this->_adapter, $args);
         $this->_plugin->onWriteItemPre($event);
 
@@ -118,7 +117,7 @@ class SerializerTest extends CommonPluginTest
         $value    = 123;
         $valueSer = serialize($value);
         
-        $args  = new ArrayObject(['key' => $key, 'success'  => true, 'casToken' => null]);
+        $args  = ['key' => $key, 'success'  => true, 'casToken' => null];
         $event = new PostEvent('getItem.post', $this->_adapter, $args, $valueSer);
         $this->_plugin->onReadItemPost($event);
 
@@ -128,10 +127,10 @@ class SerializerTest extends CommonPluginTest
 
     public function testDontUnserializeOnReadMissingItemPost()
     {
-        $key      = 'testKey';
-        $value    = null;
+        $key   = 'testKey';
+        $value = null;
 
-        $args  = new ArrayObject(['key' => $key]);
+        $args  = ['key' => $key];
         $event = new PostEvent('getItem.post', $this->_adapter, $args, $value);
         $this->_plugin->onReadItemPost($event);
 
@@ -142,7 +141,7 @@ class SerializerTest extends CommonPluginTest
     public function testUnserializeOnReadItemsPost()
     {
         $values = ['key1' => serialize(123), 'key2' => serialize(456)];
-        $args   = new ArrayObject(['keys' => array_keys($values) + ['missing']]);
+        $args   = ['keys' => array_keys($values) + ['missing']];
         $event  = new PostEvent('getItems.post', $this->_adapter, $args, $values);
         $this->_plugin->onReadItemsPost($event);
 
@@ -169,7 +168,7 @@ class SerializerTest extends CommonPluginTest
             ]
         ]);
 
-        $event = new PostEvent('getCapabilities.post', $this->_adapter, new ArrayObject(), $baseCapabilities);
+        $event = new PostEvent('getCapabilities.post', $this->_adapter, [], $baseCapabilities);
         $this->_plugin->onGetCapabilitiesPost($event);
 
         $this->assertFalse($event->propagationIsStopped(), 'Event propagation has been stopped');

--- a/test/Storage/TestAsset/MockAdapter.php
+++ b/test/Storage/TestAsset/MockAdapter.php
@@ -14,15 +14,15 @@ use Zend\Cache\Storage\Adapter\AbstractAdapter;
 class MockAdapter extends AbstractAdapter
 {
 
-    protected function internalGetItem(& $normalizedKey, & $success = null, & $casToken = null)
+    protected function internalGetItem($normalizedKey, & $success = null, & $casToken = null)
     {
     }
 
-    protected function internalSetItem(& $normalizedKey, & $value)
+    protected function internalSetItem($normalizedKey, $value)
     {
     }
 
-    protected function internalRemoveItem(& $normalizedKey)
+    protected function internalRemoveItem($normalizedKey)
     {
     }
 }


### PR DESCRIPTION
This PR reduces arguments by reference often used on internal methods.

It was previously done as performance improvement but in fact it decreases performance as PHP have to create a new zval and in some cases it needs to copy the value before PHP-7 as described here: http://nikic.github.io/2015/05/05/Internal-value-representation-in-PHP-7-part-1.html

Additionally arguments by reference make the code more error prone and hard to read.
