### PR TITLE
Fix undefined index persistent_id on RedisResourceManager

### DIFF
--- a/src/Storage/Adapter/RedisResourceManager.php
+++ b/src/Storage/Adapter/RedisResourceManager.php
@@ -264,7 +264,7 @@ class RedisResourceManager
         $redis  = $resource['resource'];
         if ($resource['persistent_id'] !== '') {
             //connect or reuse persistent connection
-            $success = $redis->pconnect($server['host'], $server['port'], $server['timeout'], $server['persistent_id']);
+            $success = $redis->pconnect($server['host'], $server['port'], $server['timeout'], $resource['persistent_id']);
         } elseif ($server['port']) {
             $success = $redis->connect($server['host'], $server['port'], $server['timeout']);
         } elseif ($server['timeout']) {

--- a/test/Storage/Adapter/RedisResourceManagerTest.php
+++ b/test/Storage/Adapter/RedisResourceManagerTest.php
@@ -33,6 +33,14 @@ class RedisResourceManagerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test get the Redis resource
+     */
+    public function testGetResource()
+    {
+
+    }
+
+    /**
      * @group 6495
      */
     public function testSetServerWithPasswordInUri()
@@ -111,6 +119,7 @@ class RedisResourceManagerTest extends \PHPUnit_Framework_TestCase
         $expectedPersistentId = '1234';
         $this->resourceManager->setResource($resourceId, $resource);
         $this->assertSame($expectedPersistentId, $this->resourceManager->getPersistentId($resourceId));
+        $this->assertInstanceOf('Redis', $this->resourceManager->getResource($resourceId));
     }
 
     /**
@@ -130,5 +139,6 @@ class RedisResourceManagerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNotSame($expectedPersistentId, $this->resourceManager->getPersistentId($resourceId));
         $this->assertEmpty($this->resourceManager->getPersistentId($resourceId));
+        $this->assertInstanceOf('Redis', $this->resourceManager->getResource($resourceId));
     }
 }

--- a/test/Storage/Adapter/RedisResourceManagerTest.php
+++ b/test/Storage/Adapter/RedisResourceManagerTest.php
@@ -33,14 +33,6 @@ class RedisResourceManagerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test get the Redis resource
-     */
-    public function testGetResource()
-    {
-
-    }
-
-    /**
      * @group 6495
      */
     public function testSetServerWithPasswordInUri()

--- a/test/Storage/Adapter/RedisResourceManagerTest.php
+++ b/test/Storage/Adapter/RedisResourceManagerTest.php
@@ -101,6 +101,14 @@ class RedisResourceManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidPersistentId()
     {
+        if (!getenv('TESTS_ZEND_CACHE_REDIS_ENABLED')) {
+            $this->markTestSkipped('Enable TESTS_ZEND_CACHE_REDIS_ENABLED to run this test');
+        }
+
+        if (!extension_loaded('redis')) {
+            $this->markTestSkipped("Redis extension is not loaded");
+        }
+
         $resourceId = 'testValidPersistentId';
         $resource   = [
             'persistent_id' => 1234,
@@ -119,6 +127,14 @@ class RedisResourceManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function testNotValidPersistentId()
     {
+        if (!getenv('TESTS_ZEND_CACHE_REDIS_ENABLED')) {
+            $this->markTestSkipped('Enable TESTS_ZEND_CACHE_REDIS_ENABLED to run this test');
+        }
+
+        if (!extension_loaded('redis')) {
+            $this->markTestSkipped("Redis extension is not loaded");
+        }
+
         $resourceId = 'testNotValidPersistentId';
         $resource   = [
             'persistend_id' => 1234,


### PR DESCRIPTION
In the RedisResourceManager there was a reference to a wrong variable (`$server` instead of `$resource`).

Added also some tests to catch the error during the test of the persistent id.

Refer to #3 , I have created a new PR to clean my code from other local branches that was creating troubles.