### PR TITLE
Set ttl to specific cache key for Redis Storage Adapter

### DIFF
--- a/test/Storage/Adapter/RedisTest.php
+++ b/test/Storage/Adapter/RedisTest.php
@@ -312,4 +312,20 @@ class RedisTest extends CommonAdapterTest
         $this->_options->setPassword($password);
         $this->assertEquals($password, $this->_options->getPassword(), 'Password was set incorrectly using RedisOptions');
     }
+
+    public function testTouchItem()
+    {
+        $key = 'key';
+
+        // no TTL
+        $this->_storage->getOptions()->setTtl(0);
+        $this->_storage->setItem($key, 'val');
+        $this->assertEquals(0, $this->_storage->getMetadata($key)['ttl']);
+
+        // touch with a specific TTL will add this TTL
+        $ttl = 1000;
+        $this->_storage->getOptions()->setTtl($ttl);
+        $this->assertTrue($this->_storage->touchItem($key));
+        $this->assertEquals($ttl, ceil($this->_storage->getMetadata($key)['ttl']));
+    }
 }


### PR DESCRIPTION
- Implemented the `internalTouchItem` method inside `Storage\Adapter\Redis` that allow to touch a Redis item.
- Implemented the `_ttl` metadata, that return the remaining tll of a specific key

Thanks to @marc-mabe to help me understanding what to do!

Refer to #5, I have created a new PR to clean my code from other local branches that was creating troubles.