### PR TITLE
Changed to public all the getXXXResource methods of the cache adapters

### DIFF
--- a/src/Storage/Adapter/Memcache.php
+++ b/src/Storage/Adapter/Memcache.php
@@ -77,7 +77,7 @@ class Memcache extends AbstractAdapter implements
      *
      * @return MemcacheResource
      */
-    protected function getMemcacheResource()
+    public function getMemcacheResource()
     {
         if ($this->initialized) {
             return $this->resourceManager->getResource($this->resourceId);

--- a/src/Storage/Adapter/Memcached.php
+++ b/src/Storage/Adapter/Memcached.php
@@ -89,7 +89,7 @@ class Memcached extends AbstractAdapter implements
      *
      * @return MemcachedResource
      */
-    protected function getMemcachedResource()
+    public function getMemcachedResource()
     {
         if (!$this->initialized) {
             $options = $this->getOptions();

--- a/src/Storage/Adapter/MongoDb.php
+++ b/src/Storage/Adapter/MongoDb.php
@@ -75,7 +75,7 @@ class MongoDb extends AbstractAdapter implements FlushableInterface
      *
      * @return MongoResource
      */
-    private function getMongoDbResource()
+    public function getMongoDbResource()
     {
         if (! $this->initialized) {
             $options = $this->getOptions();

--- a/src/Storage/Adapter/Redis.php
+++ b/src/Storage/Adapter/Redis.php
@@ -78,7 +78,7 @@ class Redis extends AbstractAdapter implements
      *
      * @return RedisResource
      */
-    protected function getRedisResource()
+    public function getRedisResource()
     {
         if (!$this->initialized) {
             $options = $this->getOptions();

--- a/test/Storage/Adapter/MemcacheTest.php
+++ b/test/Storage/Adapter/MemcacheTest.php
@@ -150,4 +150,9 @@ class MemcacheTest extends CommonAdapterTest
 
         parent::tearDown();
     }
+
+    public function testGetMemcacheResource()
+    {
+        $this->assertInstanceOf('Memcache', $this->_storage->getMemcacheResource());
+    }
 }

--- a/test/Storage/Adapter/MemcachedTest.php
+++ b/test/Storage/Adapter/MemcachedTest.php
@@ -198,4 +198,9 @@ class MemcachedTest extends CommonAdapterTest
 
         parent::tearDown();
     }
+
+    public function testGetMemcachedResource()
+    {
+        $this->assertInstanceOf('Memcached', $this->_storage->getMemcachedResource());
+    }
 }

--- a/test/Storage/Adapter/MongoDbTest.php
+++ b/test/Storage/Adapter/MongoDbTest.php
@@ -93,4 +93,9 @@ class MongoDbTest extends CommonAdapterTest
 
         $this->assertEquals([], $this->_storage->hasItems([$key1, $key2]));
     }
+
+    public function testGetMongoDbResource()
+    {
+        $this->assertInstanceOf('MongoCollection', $this->_storage->getMongoDbResource());
+    }
 }

--- a/test/Storage/Adapter/RedisTest.php
+++ b/test/Storage/Adapter/RedisTest.php
@@ -14,18 +14,6 @@ use Redis as RedisResource;
 
 class RedisTest extends CommonAdapterTest
 {
-    /**
-     *
-     * @var Cache\Storage\Adapter\RedisOptions
-     */
-    protected $_options;
-
-    /**
-     *
-     * @var Cache\Storage\Adapter\Redis
-     */
-    protected $_storage;
-
     public function setUp()
     {
         if (!getenv('TESTS_ZEND_CACHE_REDIS_ENABLED')) {
@@ -311,5 +299,10 @@ class RedisTest extends CommonAdapterTest
         $password = 'my-secret';
         $this->_options->setPassword($password);
         $this->assertEquals($password, $this->_options->getPassword(), 'Password was set incorrectly using RedisOptions');
+    }
+
+    public function testGetRedisResource()
+    {
+        $this->assertInstanceOf('Redis', $this->_storage->getRedisResource());
     }
 }


### PR DESCRIPTION
This PR is a consequence of the issue #12

It's useful in case someone wants to obtain the resource and pass it to other modules that need the original resource, (avoid creating and configuring a new resource, but re-use the one previously configured).