### PR TITLE
persistent_id as string instead of int in tests of RedisResourceManager

### DIFF
--- a/test/Storage/Adapter/RedisResourceManagerTest.php
+++ b/test/Storage/Adapter/RedisResourceManagerTest.php
@@ -57,7 +57,7 @@ class RedisResourceManagerTest extends \PHPUnit_Framework_TestCase
         $server      = 'redis://dummyuser:dummypass@testhost:1234';
         $dummyResId2 = '12345678901';
         $resource    = [
-            'persistent_id' => 1234,
+            'persistent_id' => 'my_connection_name',
             'server'        => $server,
             'password'      => 'abcd1234'
         ];
@@ -80,7 +80,7 @@ class RedisResourceManagerTest extends \PHPUnit_Framework_TestCase
         $server2     = 'redis://dummyuser:dummypass@testhost2:1234';
         $dummyResId2 = '12345678901';
         $resource    = [
-            'persistent_id' => 1234,
+            'persistent_id' => 'my_connection_name',
             'server'        => $server,
             'password'      => 'abcd1234'
         ];
@@ -103,29 +103,29 @@ class RedisResourceManagerTest extends \PHPUnit_Framework_TestCase
     {
         $resourceId = 'testValidPersistentId';
         $resource   = [
-            'persistent_id' => 1234,
+            'persistent_id' => 'my_connection_name',
             'server' => [
                 'host' => 'localhost'
             ],
         ];
-        $expectedPersistentId = '1234';
+        $expectedPersistentId = 'my_connection_name';
         $this->resourceManager->setResource($resourceId, $resource);
         $this->assertSame($expectedPersistentId, $this->resourceManager->getPersistentId($resourceId));
     }
 
     /**
-     * Test with 'persistend_id'
+     * Test with 'persistend_id' instead of 'persistent_id'
      */
-    public function testNotValidPersistentId()
+    public function testNotValidPersistentIdOptionName()
     {
         $resourceId = 'testNotValidPersistentId';
         $resource   = [
-            'persistend_id' => 1234,
+            'persistend_id' => 'my_connection_name',
             'server' => [
                 'host' => 'localhost'
             ],
         ];
-        $expectedPersistentId = '1234';
+        $expectedPersistentId = 'my_connection_name';
         $this->resourceManager->setResource($resourceId, $resource);
 
         $this->assertNotSame($expectedPersistentId, $this->resourceManager->getPersistentId($resourceId));


### PR DESCRIPTION
Fixes #4