### PR TITLE
Cleanup composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
         "php": ">=5.5",
         "zendframework/zend-stdlib": "~2.5",
         "zendframework/zend-servicemanager": "~2.5",
-        "zendframework/zend-serializer": "~2.5",
         "zendframework/zend-eventmanager": "~2.5"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "zendframework/zend-eventmanager": "~2.5"
     },
     "require-dev": {
+        "zendframework/zend-serializer": "~2.5", 
         "zendframework/zend-session": "~2.5",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"


### PR DESCRIPTION
Serializer in is "suggest" since 99f1ee0876b1c65bfdd26228919287318fd2a4a7 and is not mandatory according to closed PR #16
So make dep consistent.