### PR TITLE
fixed AbstractAdapter::internalDecrementItems

### DIFF
--- a/src/Storage/Adapter/AbstractAdapter.php
+++ b/src/Storage/Adapter/AbstractAdapter.php
@@ -1466,7 +1466,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
     {
         $result = [];
         foreach ($normalizedKeyValuePairs as $normalizedKey => $value) {
-            $newValue = $this->decrementItem($normalizedKey, $value);
+            $newValue = $this->internalDecrementItem($normalizedKey, $value);
             if ($newValue !== false) {
                 $result[$normalizedKey] = $newValue;
             }


### PR DESCRIPTION
 * was calling `decrementItem` instead of `internalDecrementItem`
 * triggered events for bulk decrement as well as for every items

Noted by benchmarks of #35 

Before:
```
ZendBench\Cache\MemoryStorageAdapterBench
    Method Name                    Iterations   Average Time      Ops/second 
    ----------------------------- ------------ ----------------- -------------
    decrementMissingItemsSingle : [       100] [0.0008270716667] [1,209.08507]
    decrementMissingItemsBulk   : [       100] [0.0009380531311] [1,066.03770]
    decrementExistingItemsSingle: [       100] [0.0008216524124] [1,217.05965]
    decrementExistingItemsBulk  : [       100] [0.0009412384033] [1,062.43009]
```

After:
```
ZendBench\Cache\MemoryStorageAdapterBench
    Method Name                    Iterations   Average Time      Ops/second 
    ----------------------------- ------------ ----------------- -------------
    decrementMissingItemsSingle : [       100] [0.0008160185814] [1,225.46229]
    decrementMissingItemsBulk   : [       100] [0.0001660728455] [6,021.45400]
    decrementExistingItemsSingle: [       100] [0.0008193802834] [1,220.43454]
    decrementExistingItemsBulk  : [       100] [0.0001683640480] [5,939.51032]
```

PS: tests are passing but I need to write a new test catching this