### PR TITLE
disable SharedEventManager

### DIFF
--- a/src/Storage/Adapter/AbstractAdapter.php
+++ b/src/Storage/Adapter/AbstractAdapter.php
@@ -190,7 +190,6 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
     {
         if ($this->events === null) {
             $this->events = new EventManager();
-            $this->events->setIdentifiers([__CLASS__, get_class($this)]);
         }
         return $this->events;
     }

--- a/test/Storage/Adapter/EventManagerCompatibilityTest.php
+++ b/test/Storage/Adapter/EventManagerCompatibilityTest.php
@@ -11,7 +11,6 @@
 namespace ZendTest\Cache\Storage\Adapter;
 
 use PHPUnit_Framework_TestCase as TestCase;
-use Zend\Cache\Storage\Adapter\AbstractAdapter;
 use Zend\EventManager\EventManager;
 use ZendTest\Cache\Storage\TestAsset\MockAdapter;
 
@@ -32,11 +31,8 @@ class EventManagerCompatibilityTest extends TestCase
     /**
      * @depends testCanLazyLoadEventManager
      */
-    public function testLazyLoadedEventManagerIsInjectedProperlyWithDefaultIdentifiers(EventManager $events)
+    public function testLazyLoadedEventManagerWithoutDefaultIdentifiersForPerformanceReasons(EventManager $events)
     {
-        $this->assertEquals([
-            AbstractAdapter::class,
-            MockAdapter::class,
-        ], $events->getIdentifiers());
+        $this->assertEquals([], $events->getIdentifiers());
     }
 }


### PR DESCRIPTION
@weierophinney @ezimuel 
Does it makes sense for storage adapters to enable the `SharedEventManager` by default as it decreases performance a lot?

Bench:
```
ZendBench\Cache\MemoryStorageAdapterBench
Method Name                    Iterations   After Avg-Time    After Ops/s   Before Avg-Time  Before Ops/s
----------------------------- ------------ ----------------- ------------- ----------------- -------------
hasMissingItemsSingle       : [       100] [0.0006125473976] [1,632.52673] [0.0007707405090] [1,297.45354]
hasMissingItemsBulk         : [       100] [0.0001056575775] [9,464.53651] [0.0001196956635] [8,354.52155]
hasExistingItemsSingle      : [       100] [0.0006196784973] [1,613.74004] [0.0007803583145] [1,281.46261]
hasExistingItemsBulk        : [       100] [0.0001093935966] [9,141.30288] [0.0001227927208] [8,143.80522]
setExistingItemsSingle      : [       100] [0.0006658363342] [1,501.87058] [0.0008204936981] [1,218.77840]
setExistingItemsBulk        : [       100] [0.0001069116592] [9,353.51679] [0.0001227259636] [8,148.23507]
setMissingItemsSingle       : [       100] [0.0006774187088] [1,476.19188] [0.0008470153809] [1,180.61611]
setMissingItemsBulk         : [       100] [0.0001067113876] [9,371.07109] [0.0001235651970] [8,092.89367]
addItemsSingle              : [       100] [0.0006811141968] [1,468.18258] [0.0008597636223] [1,163.11039]
addItemsBulk                : [       100] [0.0001092433929] [9,153.87167] [0.0001248407364] [8,010.20587]
replaceItemsSingle          : [       100] [0.0006628966331] [1,508.53082] [0.0008225584030] [1,215.71915]
replaceItemsBulk            : [       100] [0.0001045012474] [9,569.26376] [0.0001198101044] [8,346.54143]
getCheckAndSetItemsSingle   : [       100] [0.0014570736885] [686.30709  ] [0.0017857670784] [559.98344  ]
touchMissingItemsSingle     : [       100] [0.0006158590317] [1,623.74821] [0.0007836127281] [1,276.14058]
touchMissingItemsBulk       : [       100] [0.0001326990128] [7,535.85109] [0.0001465630531] [6,823.00197]
touchExistingItemsSingle    : [       100] [0.0006380939484] [1,567.16735] [0.0007986259460] [1,252.15065]
touchExistingItemsBulk      : [       100] [0.0001424312592] [7,020.93070] [0.0001567006111] [6,381.59604]
getMissingItemsSingle       : [       100] [0.0006562280655] [1,523.86046] [0.0008175301552] [1,223.19647]
getMissingItemsBulk         : [       100] [0.0001064491272] [9,394.15875] [0.0001210737228] [8,259.43051]
getExistingItemsSingle      : [       100] [0.0006812620163] [1,467.86402] [0.0008400774002] [1,190.36651]
getExistingItemsBulk        : [       100] [0.0001136255264] [8,800.83931] [0.0001275300980] [7,841.28622]
removeMissingItemsSingle    : [       100] [0.0006146192551] [1,627.02355] [0.0007805037498] [1,281.22383]
removeMissingItemsBulk      : [       100] [0.0001329231262] [7,523.14536] [0.0001458334923] [6,857.13538]
removeExistingItemsSingle   : [       100] [0.0006292605400] [1,589.16687] [0.0007943630219] [1,258.87028]
removeExistingItemsBulk     : [       100] [0.0001381754875] [7,237.17367] [0.0001526427269] [6,551.24565]
incrementMissingItemsSingle : [       100] [0.0006532883644] [1,530.71760] [0.0008117723465] [1,231.87246]
incrementMissingItemsBulk   : [       100] [0.0001489043236] [6,715.72172] [0.0001636791229] [6,109.51465]
incrementExistingItemsSingle: [       100] [0.0006493449211] [1,540.01359] [0.0008092260361] [1,235.74867]
incrementExistingItemsBulk  : [       100] [0.0001526975632] [6,548.89298] [0.0001654624939] [6,043.66571]
decrementMissingItemsSingle : [       100] [0.0006467795372] [1,546.12189] [0.0008093261719] [1,235.59578]
decrementMissingItemsBulk   : [       100] [0.0007500600815] [1,333.22653] [0.0009214377403] [1,085.26052]
decrementExistingItemsSingle: [       100] [0.0006503605843] [1,537.60856] [0.0007983636856] [1,252.56198]
decrementExistingItemsBulk  : [       100] [0.0007511115074] [1,331.36024] [0.0009197139740] [1,087.29456]
```