### PR TITLE
fix #18: Redis::getCapabilities() error when not yet initialized

### DIFF
--- a/src/Storage/Adapter/Redis.php
+++ b/src/Storage/Adapter/Redis.php
@@ -221,12 +221,13 @@ class Redis extends AbstractAdapter implements
      */
     protected function internalSetItem(& $normalizedKey, & $value)
     {
-        $redis = $this->getRedisResource();
-        $ttl = $this->getOptions()->getTtl();
+        $redis   = $this->getRedisResource();
+        $options = $this->getOptions();
+        $ttl     = $options->getTtl();
 
         try {
             if ($ttl) {
-                if ($this->resourceManager->getMajorVersion($this->resourceId) < 2) {
+                if ($options->getResourceManager()->getMajorVersion($options->getResourceId()) < 2) {
                     throw new Exception\UnsupportedMethodCallException("To use ttl you need version >= 2.0.0");
                 }
                 $success = $redis->setex($this->namespacePrefix . $normalizedKey, $ttl, $value);
@@ -250,8 +251,9 @@ class Redis extends AbstractAdapter implements
      */
     protected function internalSetItems(array & $normalizedKeyValuePairs)
     {
-        $redis = $this->getRedisResource();
-        $ttl   = $this->getOptions()->getTtl();
+        $redis   = $this->getRedisResource();
+        $options = $this->getOptions();
+        $ttl     = $options->getTtl();
 
         $namespacedKeyValuePairs = [];
         foreach ($normalizedKeyValuePairs as $normalizedKey => $value) {
@@ -260,7 +262,7 @@ class Redis extends AbstractAdapter implements
         try {
             if ($ttl > 0) {
                 //check if ttl is supported
-                if ($this->resourceManager->getMajorVersion($this->resourceId) < 2) {
+                if ($options->getResourceManager()->getMajorVersion($options->getResourceId()) < 2) {
                     throw new Exception\UnsupportedMethodCallException("To use ttl you need version >= 2.0.0");
                 }
                 //mSet does not allow ttl, so use transaction
@@ -292,12 +294,13 @@ class Redis extends AbstractAdapter implements
      */
     protected function internalAddItem(& $normalizedKey, & $value)
     {
-        $redis = $this->getRedisResource();
-        $ttl   = $this->getOptions()->getTtl();
+        $redis   = $this->getRedisResource();
+        $options = $this->getOptions();
+        $ttl     = $options->getTtl();
 
         try {
             if ($ttl) {
-                if ($this->resourceManager->getMajorVersion($this->resourceId) < 2) {
+                if ($options->getResourceManager()->getMajorVersion($options->getResourceId()) < 2) {
                     throw new Exception\UnsupportedMethodCallException("To use ttl you need version >= 2.0.0");
                 }
 
@@ -443,7 +446,7 @@ class Redis extends AbstractAdapter implements
      */
     public function getTotalSpace()
     {
-        $redis  = $this->getRedisResource();
+        $redis = $this->getRedisResource();
         try {
             $info = $redis->info();
         } catch (RedisResourceException $e) {
@@ -465,13 +468,12 @@ class Redis extends AbstractAdapter implements
         if ($this->capabilities === null) {
             $this->capabilityMarker = new stdClass();
 
-            $redisVersion = $this->resourceManager->getMajorVersion($this->resourceId);
-            $minTtl = version_compare($redisVersion, '2', '<') ? 0 : 1;
-            $supportedMetadata = version_compare($redisVersion, '2', '>=') ? ['ttl'] : [];
+            $options      = $this->getOptions();
+            $redisVersion = $options->getResourceManager()->getMajorVersion($options->getResourceId());
+            $minTtl       = version_compare($redisVersion, '2', '<') ? 0 : 1;
+            $supportedMetadata = $redisVersion >= 2 ? ['ttl'] : [];
 
-            //without serialization redis supports only strings for simple
-            //get/set methods
-            $this->capabilities     = new Capabilities(
+            $this->capabilities = new Capabilities(
                 $this,
                 $this->capabilityMarker,
                 [

--- a/src/Storage/Adapter/RedisResourceManager.php
+++ b/src/Storage/Adapter/RedisResourceManager.php
@@ -47,12 +47,10 @@ class RedisResourceManager
      */
     public function getMajorVersion($id)
     {
-        if (!$this->hasResource($id)) {
-            throw new Exception\RuntimeException("No resource with id '{$id}'");
-        }
+        // check resource id and initialize the resource
+        $this->getResource($id);
 
-        $resource = & $this->resources[$id];
-        return (int) $resource['version'];
+        return (int) $this->resources[$id]['version'];
     }
 
     /**

--- a/test/Storage/Adapter/RedisResourceManagerTest.php
+++ b/test/Storage/Adapter/RedisResourceManagerTest.php
@@ -149,4 +149,29 @@ class RedisResourceManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertEmpty($this->resourceManager->getPersistentId($resourceId));
         $this->assertInstanceOf('Redis', $this->resourceManager->getResource($resourceId));
     }
+
+    /**
+     * Test with 'persistend_id' instead of 'persistent_id'
+     */
+    public function testGetMajorVersion()
+    {
+        if (!getenv('TESTS_ZEND_CACHE_REDIS_ENABLED')) {
+            $this->markTestSkipped('Enable TESTS_ZEND_CACHE_REDIS_ENABLED to run this test');
+        }
+
+        if (!extension_loaded('redis')) {
+            $this->markTestSkipped("Redis extension is not loaded");
+        }
+
+        $resourceId = __FUNCTION__;
+        $resource   = [
+            'server' => [
+                'host' => getenv('TESTS_ZEND_CACHE_REDIS_HOST') ?: 'localhost',
+                'port' => getenv('TESTS_ZEND_CACHE_REDIS_PORT') ?: 6379,
+            ],
+        ];
+        $this->resourceManager->setResource($resourceId, $resource);
+
+        $this->assertGreaterThan(0, $this->resourceManager->getMajorVersion($resourceId));
+    }
 }

--- a/test/Storage/Adapter/RedisTest.php
+++ b/test/Storage/Adapter/RedisTest.php
@@ -36,35 +36,25 @@ class RedisTest extends CommonAdapterTest
             $this->markTestSkipped("Redis extension is not loaded");
         }
 
-        $this->_options  = new Cache\Storage\Adapter\RedisOptions([
-            'resource_id' => __CLASS__,
-        ]);
+        $options = ['resource_id' => __CLASS__];
 
         if (getenv('TESTS_ZEND_CACHE_REDIS_HOST') && getenv('TESTS_ZEND_CACHE_REDIS_PORT')) {
-            $this->_options->getResourceManager()->setServer(__CLASS__, [
-                getenv('TESTS_ZEND_CACHE_REDIS_HOST'), getenv('TESTS_ZEND_CACHE_REDIS_PORT'), 1
-            ]);
+            $options['server'] = [getenv('TESTS_ZEND_CACHE_REDIS_HOST'), getenv('TESTS_ZEND_CACHE_REDIS_PORT')];
         } elseif (getenv('TESTS_ZEND_CACHE_REDIS_HOST')) {
-            $this->_options->getResourceManager()->setServer(__CLASS__, [
-                getenv('TESTS_ZEND_CACHE_REDIS_HOST')
-            ]);
+            $options['server'] = [getenv('TESTS_ZEND_CACHE_REDIS_HOST')];
         }
 
         if (getenv('TESTS_ZEND_CACHE_REDIS_DATABASE')) {
-            $this->_options->getResourceManager()->setDatabase(__CLASS__,
-                getenv('TESTS_ZEND_CACHE_REDIS_DATABASE')
-            );
+            $options['database'] = getenv('TESTS_ZEND_CACHE_REDIS_DATABASE');
         }
 
         if (getenv('TESTS_ZEND_CACHE_REDIS_PASSWORD')) {
-            $this->_options->getResourceManager()->setPassword(__CLASS__,
-                getenv('TESTS_ZEND_CACHE_REDIS_PASSWORD')
-            );
+            $options['password'] = getenv('TESTS_ZEND_CACHE_REDIS_PASSWORD');
         }
-        $this->_storage = new Cache\Storage\Adapter\Redis();
 
-        $this->_storage->setOptions($this->_options);
-        $this->_storage->flush();
+        $this->_options = new Cache\Storage\Adapter\RedisOptions($options);
+        $this->_storage = new Cache\Storage\Adapter\Redis($this->_options);
+
         parent::setUp();
     }
 


### PR DESCRIPTION
 - fixed `RedisResourceManager::getMajorVersion()`
   by initialize the resource before accessing version info
 - Get the resource manager/id from options
   instead of access `$this->resourceManager` which could be still not initialized
 - flush test data in `tearDown()` instead of `setUp()`
   with this change the bug gets reflected by `testGetCapabilities()`
   and it makes sure that all test data gets removed after

This PR replaces #19 