### PR TITLE
fixed seg fault in redis adapter on PHP 7

### DIFF
--- a/src/Storage/Adapter/RedisResourceManager.php
+++ b/src/Storage/Adapter/RedisResourceManager.php
@@ -332,7 +332,7 @@ class RedisResourceManager
             $resource = array_merge(
                 $defaults,
                 [
-                    'resource' => $resource,
+                    'resource'    => $resource,
                     'initialized' => isset($resource->socket),
                 ]
             );
@@ -629,15 +629,21 @@ class RedisResourceManager
      */
     public function setDatabase($id, $database)
     {
+        $database = (int) $database;
+
         if (!$this->hasResource($id)) {
             return $this->setResource($id, [
-                'database' => (int) $database,
+                'database' => $database,
             ]);
         }
 
         $resource = & $this->resources[$id];
-        $resource['database']    = $database;
-        $resource['initialized'] = false;
+        if ($resource['resource'] instanceof RedisResource && $resource['initialized']) {
+            $resource['resource']->select($database);
+        }
+
+        $resource['database'] = $database;
+
         return $this;
     }
 }


### PR DESCRIPTION
After changing selected database on an already connected object
the `RedisResourceManager` was again trying to connect which crashed.