### PR TITLE
Added PSR-6 adapter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,13 @@
         "php": "^5.5 || ^7.0",
         "zendframework/zend-stdlib": "^2.7 || ^3.0",
         "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
-        "zendframework/zend-eventmanager": "^2.6.2 || ^3.0"
+        "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
+        "psr/cache": "^1.0"
     },
     "require-dev": {
         "zendframework/zend-serializer": "^2.6",
         "zendframework/zend-session": "^2.5",
+        "cache/integration-tests": "^0.7.0",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "zendframework/zend-serializer": "^2.6",
         "zendframework/zend-session": "^2.5",
-        "cache/integration-tests": "^0.7.0",
+        "cache/integration-tests": "^0.8.0",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"
     },

--- a/doc/book/psr6.md
+++ b/doc/book/psr6.md
@@ -51,7 +51,9 @@ found.
 ## Supported adapters
 
 The PSR-6 specification requires that the underlying storage support time-to-live (TTL), which is set when the
-item is saved. For this reason the following adapters cannot be used: `Dba`, `Filesystem`, `Memory` and `Session`.
+item is saved. For this reason the following adapters cannot be used: `Dba`, `Filesystem`, `Memory` and `Session`. The 
+`XCache` adapter calculates TTLs based on the request time, not the time the item is actually persisted, which means 
+that it also cannot be used.
 
 In addition adapters must support the `Zend\Cache\FlushableInterface`. All the current `Zend\Cache\Storage\Adapter`s 
 fulfil this requirement.

--- a/doc/book/zend.cache.psr.cacheitempooladapter.md
+++ b/doc/book/zend.cache.psr.cacheitempooladapter.md
@@ -1,0 +1,130 @@
+# Zend\\Cache\\Psr\\CacheItemPoolAdapter
+
+## Overview
+
+The `Zend\Cache\Psr\CacheItemPoolAdapter` provides a [PSR-6](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-6-cache.md) 
+compliant wrapper for supported storage adapters.
+
+PSR-6 specifies a common interface to cache storage, enabling developers to switch between implementations without 
+having to worry about any behind-the-scenes differences between them.
+
+
+## Quick Start
+
+To use the pool, instantiate your storage as normal, then pass it to the `CacheItemPoolAdapter`.
+
+```php
+use Zend\Cache\StorageFactory;
+use Zend\Cache\Psr\CacheItemPoolAdapter;
+
+$storage = StorageFactory::factory([
+    'adapter' => [
+        'name'    => 'apc',
+        'options' => [],
+    ],
+]);
+
+$pool = new CacheItemPoolAdapter($storage);
+
+// attempt to get an item from cache
+$item = $pool->getItem('foo');
+
+// check whether item was found
+if (! $item->isHit()) {
+    // ...
+    // perform expensive operation to calculate $value for 'foo'
+    // ...
+    
+    $item->set($value);
+    $pool->save($item);
+}
+
+// use the value of the item
+echo $item->get();
+```
+
+Note that you will always get back a `CacheItem` object, whether it was found in cache or not: this is so `false`-y 
+values like an empty string, `null`, or `false` can be stored. Always check `isHit()` to determine if the item was
+found.
+
+
+## Supported adapters
+
+The PSR-6 specification requires that the underlying storage support time-to-live (TTL), which is set when the
+item is saved. For this reason the following adapters cannot be used: `Dba`, `Filesystem`, `Memory` and `Session`.
+
+In addition adapters must support the `Zend\Cache\FlushableInterface`. All the current `Zend\Cache\Storage\Adapter`s 
+fulfil this requirement.
+
+Attempting to use an unsupported adapter will throw an exception implementing `Psr\Cache\CacheException`.
+
+### Quirks
+
+#### APC
+
+You cannot set the [`apc.use_request_time`](http://php.net/manual/en/apc.configuration.php#ini.apc.use-request-time) 
+ini setting with the APC adapter: the specification requires that all TTL values are calculated from when the item is 
+actually saved to storage. If this is set when you instantiate the pool it will throw an exception implementing 
+`Psr\Cache\CacheException`. Changing the setting after you have instantiated the pool will result in non-standard 
+behaviour.
+
+
+## Logging errors
+
+The specification [states](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-6-cache.md#error-handling):
+
+> While caching is often an important part of application performance, it should never be a critical part of application 
+> functionality. Thus, an error in a cache system SHOULD NOT result in application failure.
+
+Once you've got your pool instance, almost all exceptions thrown by the storage will be caught and ignored. The only 
+storage exceptions that bubble up implement `Psr\Cache\InvalidArgumentException` and are typically caused by invalid 
+key errors. To be PSR-6 compliant, cache keys must not contain the following characters: `{}()/\@:`. However different 
+storage adapters may have further restrictions. Check the documentation for your particular adapter to be sure.
+
+We strongly recommend tracking exceptions caught from storage, either by logging them or recording them in some other 
+way. Doing so is as simple as adding an [`ExceptionHandler` plugin](zend.cache.storage.plugin.html#3.4). Say you have a 
+[PSR-3](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md) compliant logger 
+called `$logger`:
+
+
+```php
+$cacheLogger = function (\Exception $e) use ($logger) {
+    $message = sprintf(
+        '[CACHE] %s:%s %s "%s"',
+        $exception->getFile(),
+        $exception->getLine(),
+        $exception->getCode(),
+        $exception->getMessage()
+    );
+    $logger->error($message);
+};
+                                }
+$storage = StorageFactory::factory([
+    'adapter' => [
+        'name'    => 'apc',
+    ],
+    'plugins' => [
+        'exceptionhandler' => [
+            'exception_callback' => $cacheLogger,
+            'throw_exceptions' => true,
+        ],
+    ],
+]);
+
+$pool = new CacheItemPoolAdapter($storage);
+```
+
+Note that `throw_exceptions` should always be `true` (the default) or you will not get the correct return values from
+calls on the pool such as `save()`.
+
+
+## Supported data types
+
+As per [the specification](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-6-cache.md#data), the 
+following data types can be stored in cache: `string`, `integer`, `float`, `boolean`, `null`, `array`, `object` and be 
+returned as a value with exactly the same type.
+
+Not all adapters can natively store all these types. For instance, Redis stores booleans and integers as a string. Where 
+this is the case *all* values will be automatically run through `serialize()` on save and `unserialize()` on get: you 
+do not need to use a `Zend\Cache\Storage\Plugin\Serializer` plugin.
+

--- a/doc/bookdown.json
+++ b/doc/bookdown.json
@@ -1,0 +1,16 @@
+{
+    "title": "Zend\\Cache",
+    "target": "html/",
+    "content": [
+        "book/zend.cache.storage.adapter.md",
+        "book/zend.cache.storage.capabilities.md",
+        "book/zend.cache.storage.plugin.md",
+        "book/zend.cache.pattern.md",
+        "book/zend.cache.pattern.callback-cache.md",
+        "book/zend.cache.pattern.class-cache.md",
+        "book/zend.cache.pattern.object-cache.md",
+        "book/zend.cache.pattern.output-cache.md",
+        "book/zend.cache.pattern.capture-cache.md",
+        "book/zend.cache.psr.cacheitempooladapter.md"
+    ]
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ pages:
         - ObjectCache: pattern/object-cache.md
         - OutputCache: pattern/output-cache.md
         - CaptureCache: pattern/capture-cache.md
+    - PSR-6: psr6.md
 site_name: zend-cache
 site_description: Zend\Cache
 repo_url: 'https://github.com/zendframework/zend-cache'

--- a/src/Psr/CacheException.php
+++ b/src/Psr/CacheException.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/).
+ *
+ * @link      http://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+namespace Zend\Cache\Psr;
+
+use Psr\Cache\CacheException as CacheExceptionInterface;
+
+class CacheException extends \RuntimeException implements CacheExceptionInterface
+{
+}

--- a/src/Psr/CacheException.php
+++ b/src/Psr/CacheException.php
@@ -6,6 +6,7 @@
  * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
+
 namespace Zend\Cache\Psr;
 
 use Psr\Cache\CacheException as CacheExceptionInterface;

--- a/src/Psr/CacheItem.php
+++ b/src/Psr/CacheItem.php
@@ -6,6 +6,7 @@
  * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
+
 namespace Zend\Cache\Psr;
 
 use DateInterval;

--- a/src/Psr/CacheItem.php
+++ b/src/Psr/CacheItem.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/).
+ *
+ * @link      http://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+namespace Zend\Cache\Psr;
+
+use DateInterval;
+use DateTime;
+use DateTimeInterface;
+use DateTimeZone;
+use Psr\Cache\CacheItemInterface;
+
+final class CacheItem implements CacheItemInterface
+{
+    /**
+     * Cache key
+     * @var string
+     */
+    private $key;
+
+    /**
+     * Cache value
+     * @var mixed|null
+     */
+    private $value;
+
+    /**
+     * True if the cache item lookup resulted in a cache hit or if they item is deferred or successfully saved
+     * @var bool
+     */
+    private $isHit = false;
+
+    /**
+     * Timestamp item will expire at if expiresAt() called, null otherwise
+     * @var int|null
+     */
+    private $expiration = null;
+
+    /**
+     * Seconds after item is stored it will expire at if expiresAfter() called, null otherwise
+     * @var int|null
+     */
+    private $ttl = null;
+
+    /**
+     * @var DateTimeZone
+     */
+    private $tz;
+
+    /**
+     * Constructor.
+     *
+     * @param string $key
+     * @param mixed $value
+     * @param bool $isHit
+     */
+    public function __construct($key, $value, $isHit)
+    {
+        $this->key = $key;
+        $this->value = $isHit ? $value : null;
+        $this->isHit = $isHit;
+        $this->tz = new DateTimeZone('UTC');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getKey()
+    {
+        return $this->key;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get()
+    {
+        return $this->value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isHit()
+    {
+        if (! $this->isHit) {
+            return false;
+        }
+        $ttl = $this->getTtl();
+        return $ttl === null || $ttl > 0;
+    }
+
+    /**
+     * Sets isHit value
+     *
+     * This function is called by CacheItemPoolAdapter::saveDeferred() and is not intended for use by other calling
+     * code.
+     *
+     * @param boolean $isHit
+     * @return $this
+     */
+    public function setIsHit($isHit)
+    {
+        $this->isHit = $isHit;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function set($value)
+    {
+        $this->value = $value;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function expiresAt($expiration)
+    {
+        if (! ($expiration === null || $expiration instanceof DateTimeInterface)) {
+            throw new InvalidArgumentException('$expiration must be null or an instance of DateTimeInterface');
+        }
+
+        $this->expiration = $expiration instanceof DateTimeInterface ? $expiration->getTimestamp() : null;
+        $this->ttl = null;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function expiresAfter($time)
+    {
+        if ($time instanceof DateInterval) {
+            $end = new DateTime('now', $this->tz);
+            $end->add($time);
+            $this->ttl = $end->getTimestamp() - time();
+        } elseif (is_int($time) || $time === null) {
+            $this->ttl = $time;
+        } else {
+            throw new InvalidArgumentException(sprintf('Invalid $time "%s"', gettype($time)));
+        }
+
+        $this->expiration = null;
+
+        return $this;
+    }
+
+    /**
+     * Returns number of seconds until item expires
+     *
+     * If NULL, the pool should use the default TTL for the storage adapter. If <= 0, the item has expired.
+     *
+     * @return int|null
+     */
+    public function getTtl()
+    {
+        $ttl = $this->ttl;
+        if ($this->expiration !== null) {
+            $ttl = $this->expiration - time();
+        }
+        return $ttl;
+    }
+}

--- a/src/Psr/CacheItemPoolAdapter.php
+++ b/src/Psr/CacheItemPoolAdapter.php
@@ -11,7 +11,6 @@ namespace Zend\Cache\Psr;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Zend\Cache\Exception;
-use Zend\Cache\Storage\Adapter\Apc;
 use Zend\Cache\Storage\ClearByNamespaceInterface;
 use Zend\Cache\Storage\FlushableInterface;
 use Zend\Cache\Storage\StorageInterface;
@@ -321,18 +320,18 @@ class CacheItemPoolAdapter implements CacheItemPoolInterface
             ));
         }
 
-        if ($storage instanceof Apc && ini_get('apc.use_request_time')) {
-            throw new CacheException(sprintf(
-                'Cannot use %s with apc.use_request_time = 1',
-                get_class($storage)
-            ));
-        }
-
         // we've got to be able to set per-item TTL on write
         $capabilities = $storage->getCapabilities();
         if (!($capabilities->getStaticTtl() && $capabilities->getMinTtl())) {
             throw new CacheException(sprintf(
                 'Storage %s does not support static TTL',
+                get_class($storage)
+            ));
+        }
+
+        if ($capabilities->getUseRequestTime()) {
+            throw new CacheException(sprintf(
+                'Cannot use %s with useRequestTime = true',
                 get_class($storage)
             ));
         }

--- a/src/Psr/CacheItemPoolAdapter.php
+++ b/src/Psr/CacheItemPoolAdapter.php
@@ -1,0 +1,420 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/).
+ *
+ * @link      http://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+namespace Zend\Cache\Psr;
+
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Zend\Cache\Exception;
+use Zend\Cache\Storage\Adapter\Apc;
+use Zend\Cache\Storage\ClearByNamespaceInterface;
+use Zend\Cache\Storage\FlushableInterface;
+use Zend\Cache\Storage\StorageInterface;
+
+/**
+ * PSR-6 cache adapter
+ *
+ * @link https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-6-cache.md
+ * @link https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-6-cache-meta.md
+ */
+class CacheItemPoolAdapter implements CacheItemPoolInterface
+{
+    /**
+     * @var StorageInterface
+     */
+    private $storage;
+
+    /**
+     * @var CacheItem[]
+     */
+    private $deferred = [];
+
+    /**
+     * @var bool
+     */
+    private $serializeValues = false;
+
+    /**
+     * @var string
+     */
+    private static $serializedFalse;
+
+    /**
+     * Constructor.
+     *
+     * PSR-6 requires that all implementing libraries support TTL so the given storage adapter must also support static
+     * TTL or an exception will be raised. Currently the following adapters do *not* support static TTL: Dba,
+     * Filesystem, Memory, Session and Redis < v2.
+     *
+     * @param StorageInterface $storage
+     *
+     * @throws CacheException
+     */
+    public function __construct(StorageInterface $storage)
+    {
+        $this->validateStorage($storage);
+
+        $this->serializeValues = $this->shouldSerialize($storage);
+        if ($this->serializeValues) {
+            static::$serializedFalse = serialize(false);
+        }
+
+        $this->storage = $storage;
+    }
+
+    /**
+     * Destructor.
+     *
+     * Saves any deferred items that have not been committed
+     */
+    public function __destruct()
+    {
+        $this->commit();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getItem($key)
+    {
+        $this->validateKey($key);
+
+        if (! $this->hasDeferredItem($key)) {
+            $value = null;
+            $isHit = false;
+            try {
+                $value = $this->storage->getItem($key, $isHit);
+
+                if ($this->serializeValues && $isHit) {
+                    // will set $isHit = false if unserialization fails
+                    extract($this->unserialize($value));
+                }
+            } catch (Exception\InvalidArgumentException $e) {
+                throw new InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
+            } catch (Exception\ExceptionInterface $e) {
+                // ignore
+            }
+
+            return new CacheItem($key, $value, $isHit);
+        } else {
+            return clone $this->deferred[$key];
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getItems(array $keys = [])
+    {
+        $this->validateKeys($keys);
+        $items = [];
+
+        // check deferred items first
+        foreach ($keys as $key) {
+            if ($this->hasDeferredItem($key)) {
+                // dereference deferred items
+                $items[$key] = clone $this->deferred[$key];
+            }
+        }
+
+        $keys = array_diff($keys, array_keys($items));
+
+        if (count($keys)) {
+            try {
+                $cacheItems = $this->storage->getItems($keys);
+            } catch (Exception\InvalidArgumentException $e) {
+                throw new InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
+            } catch (Exception\ExceptionInterface $e) {
+                $cacheItems = [];
+            }
+
+            foreach ($cacheItems as $key => $value) {
+                $isHit = true;
+                if ($this->serializeValues) {
+                    // will set $isHit = false if unserialization fails
+                    extract($this->unserialize($value));
+                }
+
+                $items[$key] = new CacheItem($key, $value, $isHit);
+            }
+
+            // Return empty items for any keys that where not found
+            foreach (array_diff($keys, array_keys($cacheItems)) as $key) {
+                $items[$key] = new CacheItem($key, null, false);
+            }
+        }
+
+        return $items;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasItem($key)
+    {
+        $this->validateKey($key);
+
+        // check deferred items first
+        $hasItem = $this->hasDeferredItem($key);
+
+        if (!$hasItem) {
+            try {
+                $hasItem = $this->storage->hasItem($key);
+            } catch (Exception\InvalidArgumentException $e) {
+                throw new InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
+            } catch (Exception\ExceptionInterface $e) {
+                $hasItem = false;
+            }
+        }
+
+        return $hasItem;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * If the storage adapter supports namespaces and one has been set, only that namespace is cleared; otherwise
+     * entire cache is flushed.
+     */
+    public function clear()
+    {
+        $this->deferred = [];
+
+        try {
+            $namespace = $this->storage->getOptions()->getNamespace();
+            if ($this->storage instanceof ClearByNamespaceInterface && $namespace) {
+                $cleared = $this->storage->clearByNamespace($namespace);
+            } else {
+                $cleared = $this->storage->flush();
+            }
+        } catch (Exception\ExceptionInterface $e) {
+            $cleared = false;
+        }
+
+        return $cleared;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteItem($key)
+    {
+        return $this->deleteItems([$key]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteItems(array $keys)
+    {
+        $this->validateKeys($keys);
+
+        $deleted = true;
+
+        // remove deferred items first
+        $this->deferred = array_diff_key($this->deferred, array_flip($keys));
+
+        try {
+            $this->storage->removeItems($keys);
+        } catch (Exception\InvalidArgumentException $e) {
+            throw new InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
+        } catch (Exception\ExceptionInterface $e) {
+            $deleted = false;
+        }
+
+        return $deleted;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function save(CacheItemInterface $item)
+    {
+        if (!$item instanceof CacheItem) {
+            throw new InvalidArgumentException('$item must be an instance of ' . CacheItem::class);
+        }
+
+        $saved = true;
+        $options = $this->storage->getOptions();
+        $ttl = $options->getTtl();
+        try {
+            // serialize value, if required
+            $value = $item->get();
+            if ($this->serializeValues) {
+                $value = serialize($value);
+            }
+
+            // reset TTL on adapter, if required
+            $itemTtl = $item->getTtl();
+            if ($itemTtl > 0) {
+                $options->setTtl($itemTtl);
+            }
+
+            // don't save items that have already expired
+            if ($itemTtl === null || $itemTtl > 0) {
+                $saved = $this->storage->setItem($item->getKey(), $value);
+                // saved items are a hit? see integration test CachePoolTest::testIsHit()
+                $item->setIsHit($saved);
+            }
+        } catch (Exception\InvalidArgumentException $e) {
+            throw new InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
+        } catch (Exception\ExceptionInterface $e) {
+            $saved = false;
+        } finally {
+            $options->setTtl($ttl);
+        }
+
+        return $saved;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function saveDeferred(CacheItemInterface $item)
+    {
+        if (!$item instanceof CacheItem) {
+            throw new InvalidArgumentException('$item must be an instance of ' . CacheItem::class);
+        }
+
+        // deferred items should always be a 'hit' until they expire
+        $item->setIsHit(true);
+        $this->deferred[$item->getKey()] = $item;
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function commit()
+    {
+        $notSaved = [];
+
+        foreach ($this->deferred as &$item) {
+            if (! $this->save($item)) {
+                $notSaved[] = $item;
+            }
+        }
+        $this->deferred = $notSaved;
+
+        return empty($this->deferred);
+    }
+
+    /**
+     * Throws exception is storage is not compatible with PSR-6
+     * @param StorageInterface $storage
+     * @throws CacheException
+     */
+    private function validateStorage(StorageInterface $storage)
+    {
+        // all current adapters implement this
+        if (!$storage instanceof FlushableInterface) {
+            throw new CacheException(sprintf(
+                'Storage %s does not implement %s',
+                get_class($storage),
+                FlushableInterface::class
+            ));
+        }
+
+        if ($storage instanceof Apc && ini_get('apc.use_request_time')) {
+            throw new CacheException(sprintf(
+                'Cannot use %s with apc.use_request_time = 1',
+                get_class($storage)
+            ));
+        }
+
+        // we've got to be able to set per-item TTL on write
+        $capabilities = $storage->getCapabilities();
+        if (!($capabilities->getStaticTtl() && $capabilities->getMinTtl())) {
+            throw new CacheException(sprintf(
+                'Storage %s does not support static TTL',
+                get_class($storage)
+            ));
+        }
+    }
+
+    /**
+     * Returns true if capabilities indicate values should be serialized before saving to preserve data types
+     * @param StorageInterface $storage
+     * @return bool
+     */
+    private function shouldSerialize(StorageInterface $storage)
+    {
+        $capabilities = $storage->getCapabilities();
+        $requiredTypes = ['string', 'integer', 'double', 'boolean', 'NULL', 'array', 'object'];
+        $types = $capabilities->getSupportedDatatypes();
+        foreach ($requiredTypes as $type) {
+            // 'object' => 'object' is OK
+            // 'integer' => 'string' is not (redis)
+            // 'integer' => 'integer' is not (memcache)
+            if (!(isset($types[$type]) && in_array($types[$type], [true, 'array', 'object'], true))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Unserializes value, marking isHit false if it fails
+     * @param $value
+     * @return array
+     */
+    private function unserialize($value)
+    {
+        if ($value == static::$serializedFalse) {
+            return ['value' => false, 'isHit' => true];
+        }
+
+        if (false === ($value = unserialize($value))) {
+            return ['value' => null, 'isHit' => false];
+        }
+
+        return ['value' => $value, 'isHit' => true];
+    }
+
+    /**
+     * Returns true if deferred item exists for given key and has not expired
+     * @param string $key
+     * @return bool
+     */
+    private function hasDeferredItem($key)
+    {
+        if (isset($this->deferred[$key])) {
+            $ttl = $this->deferred[$key]->getTtl();
+            return $ttl === null || $ttl > 0;
+        }
+        return false;
+    }
+
+    /**
+     * Throws exception if given key is invalid
+     * @param mixed $key
+     * @throws InvalidArgumentException
+     */
+    private function validateKey($key)
+    {
+        if (!is_string($key) || preg_match('#[{}()/\\\\@:]#', $key)) {
+            throw new InvalidArgumentException(sprintf(
+                "Key must be a string and not contain '{}()/\\@:'; '%s' given",
+                is_string($key) ? $key : gettype($key))
+            );
+        }
+    }
+
+    /**
+     * Throws exception if any of given keys is invalid
+     * @param array $keys
+     * @throws InvalidArgumentException
+     */
+    private function validateKeys($keys)
+    {
+        foreach ($keys as $key) {
+            $this->validateKey($key);
+        }
+    }
+}

--- a/src/Psr/InvalidArgumentException.php
+++ b/src/Psr/InvalidArgumentException.php
@@ -6,6 +6,7 @@
  * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
+
 namespace Zend\Cache\Psr;
 
 use Psr\Cache\InvalidArgumentException as InvalidArgumentExceptionInterface;

--- a/src/Psr/InvalidArgumentException.php
+++ b/src/Psr/InvalidArgumentException.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/).
+ *
+ * @link      http://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+namespace Zend\Cache\Psr;
+
+use Psr\Cache\InvalidArgumentException as InvalidArgumentExceptionInterface;
+
+class InvalidArgumentException extends \InvalidArgumentException implements InvalidArgumentExceptionInterface
+{
+}

--- a/test/Psr/ApcIntegrationTest.php
+++ b/test/Psr/ApcIntegrationTest.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/).
+ *
+ * @link      http://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+namespace ZendTest\Cache\Psr;
+
+use Cache\IntegrationTests\CachePoolTest;
+use Zend\Cache\Psr\CacheItemPoolAdapter;
+use Zend\Cache\StorageFactory;
+
+/**
+ * @requires extension apcu
+ */
+class ApcIntegrationTest extends CachePoolTest
+{
+    private $tz;
+    /**
+     * Restore 'apc.use_request_time'
+     *
+     * @var mixed
+     */
+    protected $iniUseRequestTime;
+
+    protected function setUp()
+    {
+        if (!getenv('TESTS_ZEND_CACHE_APC_ENABLED')) {
+            $this->markTestSkipped('Enable TESTS_ZEND_CACHE_APC_ENABLED to run this test');
+        }
+
+        // set non-UTC timezone
+        $this->tz = date_default_timezone_get();
+        date_default_timezone_set('America/Vancouver');
+
+        // needed on test expirations
+        $this->iniUseRequestTime = ini_get('apc.use_request_time');
+        ini_set('apc.use_request_time', 0);
+
+        parent::setUp();
+    }
+
+    protected function tearDown()
+    {
+        date_default_timezone_set($this->tz);
+
+        if (function_exists('apc_clear_cache')) {
+            apc_clear_cache('user');
+        }
+
+        // reset ini configurations
+        ini_set('apc.use_request_time', $this->iniUseRequestTime);
+
+        parent::tearDown();
+    }
+
+    /**
+     * @expectedException \Zend\Cache\Psr\CacheException
+     */
+    public function testApcUseRequestTimeThrowsException()
+    {
+        ini_set('apc.use_request_time', 1);
+        $this->createCachePool();
+    }
+
+    public function createCachePool()
+    {
+        $storage = StorageFactory::factory([
+            'adapter' => [
+                'name'    => 'apc',
+                'options' => [],
+            ],
+        ]);
+
+        return new CacheItemPoolAdapter($storage);
+    }
+}

--- a/test/Psr/ApcIntegrationTest.php
+++ b/test/Psr/ApcIntegrationTest.php
@@ -6,6 +6,7 @@
  * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
+
 namespace ZendTest\Cache\Psr;
 
 use Cache\IntegrationTests\CachePoolTest;

--- a/test/Psr/BlackHoleIntegrationTest.php
+++ b/test/Psr/BlackHoleIntegrationTest.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @author matt
+ * @copyright 2015 Claritum Limited
+ * @license Commercial
+ */
+
+namespace ZendTest\Cache\Psr;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Cache\Psr\CacheItemPoolAdapter;
+use Zend\Cache\StorageFactory;
+
+class BlackHoleIntegrationTest extends TestCase
+{
+    /**
+     * @expectedException \Zend\Cache\Psr\CacheException
+     */
+    public function testAdapterNotSupported()
+    {
+        $storage = StorageFactory::factory([
+            'adapter' => [
+                'name'    => 'blackhole',
+                'options' => [],
+            ],
+        ]);
+
+        new CacheItemPoolAdapter($storage);
+    }
+}

--- a/test/Psr/BlackHoleIntegrationTest.php
+++ b/test/Psr/BlackHoleIntegrationTest.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * @author matt
- * @copyright 2015 Claritum Limited
- * @license Commercial
+ * Zend Framework (http://framework.zend.com/).
+ *
+ * @link      http://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
 namespace ZendTest\Cache\Psr;

--- a/test/Psr/CacheItemPoolAdapterTest.php
+++ b/test/Psr/CacheItemPoolAdapterTest.php
@@ -1,0 +1,560 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/).
+ *
+ * @link      http://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+namespace ZendTest\Cache;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Prophecy\Argument;
+use Psr\Cache\CacheItemInterface;
+use Zend\Cache\Exception;
+use Zend\Cache\Psr\CacheItemPoolAdapter;
+use Zend\Cache\Storage\Adapter\AbstractAdapter;
+use Zend\Cache\Storage\StorageInterface;
+use ZendTest\Cache\Psr\MockStorageTrait;
+
+class CacheItemPoolAdapterTest extends TestCase
+{
+    use MockStorageTrait;
+
+    /**
+     * @expectedException \Zend\Cache\Psr\CacheException
+     */
+    public function testStorageNotFlushableThrowsException()
+    {
+        $storage = $this->prophesize(StorageInterface::class);
+        $this->getAdapter($storage);
+    }
+
+    /**
+     * @expectedException \Zend\Cache\Psr\CacheException
+     */
+    public function testStorageFalseStaticTtlThrowsException()
+    {
+        $storage = $this->getStorageProphesy(['staticTtl' => false]);
+        $this->getAdapter($storage);
+    }
+
+    /**
+     * @expectedException \Zend\Cache\Psr\CacheException
+     */
+    public function testStorageZeroMinTtlThrowsException()
+    {
+        $storage = $this->getStorageProphesy(['staticTtl' => true, 'minTtl' => 0]);
+        $this->getAdapter($storage);
+    }
+
+    public function testUnserialize()
+    {
+        // we can't test this without reflection: we can't prophesy args-by-ref (ie $storage->getItem('key', $isHit))
+        $unserialize = new \ReflectionMethod(CacheItemPoolAdapter::class, 'unserialize');
+        $unserialize->setAccessible(true);
+
+        $capabilities = $this->defaultCapabilities;
+        $capabilities['supportedDatatypes']['object'] = false;
+        $storage = $this->getStorageProphesy($capabilities);
+        $adapter = $this->getAdapter($storage);
+
+        $value = false;
+        $result = $unserialize->invoke($adapter, serialize($value));
+        $this->assertTrue($result['isHit'], "False value should be a hit");
+        $this->assertFalse($result['value'], "False value should be unserialized correctly");
+
+        $value = ['a' => 'b'];
+        $result = $unserialize->invoke($adapter, serialize($value));
+        $this->assertTrue($result['isHit'], "Array should be a hit");
+        $this->assertEquals($value, $result['value'], "Array should be unserialized correctly");
+
+        $result = $unserialize->invoke($adapter, null);
+        $this->assertFalse($result['isHit'], "Unserializable value should not be a hit");
+        $this->assertNull($result['value'], "Unserializable value should be null");
+    }
+
+    public function testUnsupportedDatatypeSerializesValues()
+    {
+        $test = ['a' => 'b'];
+        foreach ($this->defaultCapabilities['supportedDatatypes'] as $type => $value) {
+            if ($value) {
+                $capabilities = $this->defaultCapabilities;
+                $capabilities['supportedDatatypes'][$type] = false;
+                $storage = $this->getStorageProphesy($capabilities, false, AbstractAdapter::class);
+                $adapter = $this->getAdapter($storage);
+                $item = $adapter->getItem('foo');
+                $item->set($test);
+                $adapter->save($item);
+                $items = $adapter->getItems(['foo']);
+                $this->assertEquals($test, $items['foo']->get());
+            }
+        }
+    }
+
+    public function testGetDeferredItem()
+    {
+        $adapter = $this->getAdapter();
+        $item = $adapter->getItem('foo');
+        $item->set('bar');
+        $adapter->saveDeferred($item);
+        $item = $adapter->getItem('foo');
+        $this->assertTrue($item->isHit());
+        $this->assertEquals('bar', $item->get());
+    }
+
+    /**
+     * @dataProvider invalidKeyProvider
+     * @expectedException \Zend\Cache\Psr\InvalidArgumentException
+     */
+    public function testGetItemInvalidKeyThrowsException($key)
+    {
+        $this->getAdapter()->getItem($key);
+    }
+
+    public function testGetItemRuntimeExceptionIsMiss()
+    {
+        $storage = $this->getStorageProphesy();
+        $storage->getItem(Argument::type('string'), Argument::any())
+            ->willThrow(Exception\RuntimeException::class);
+        $adapter = $this->getAdapter($storage);
+        $item = $adapter->getItem('foo');
+        $this->assertFalse($item->isHit());
+    }
+
+    /**
+     * @expectedException \Zend\Cache\Psr\InvalidArgumentException
+     */
+    public function testGetItemInvalidArgumentExceptionRethrown()
+    {
+        $storage = $this->getStorageProphesy();
+        $storage->getItem(Argument::type('string'), Argument::any())
+            ->willThrow(Exception\InvalidArgumentException::class);
+        $this->getAdapter($storage)->getItem('foo');
+    }
+
+    public function testGetNonexistentItems()
+    {
+        $keys = ['foo', 'bar'];
+        $adapter = $this->getAdapter();
+        $items = $adapter->getItems($keys);
+        $this->assertEquals($keys, array_keys($items));
+        foreach ($keys as $key) {
+            $this->assertEquals($key, $items[$key]->getKey());
+        }
+        foreach ($items as $item) {
+            $this->assertNull($item->get());
+            $this->assertFalse($item->isHit());
+        }
+    }
+
+    public function testGetDeferredItems()
+    {
+        $keys = ['foo', 'bar'];
+        $adapter = $this->getAdapter();
+        $items = $adapter->getItems($keys);
+        foreach ($items as $item) {
+            $item->set('baz');
+            $adapter->saveDeferred($item);
+        }
+        $items = $adapter->getItems($keys);
+        foreach ($items as $item) {
+            $this->assertTrue($item->isHit());
+        }
+    }
+
+    public function testGetMixedItems()
+    {
+        $keys = ['foo', 'bar'];
+        $storage = $this->getStorageProphesy();
+        $storage->getItems($keys)
+            ->willReturn(['bar' => 'value']);
+        $items = $this->getAdapter($storage)->getItems($keys);
+        $this->assertEquals(2, count($items));
+        $this->assertNull($items['foo']->get());
+        $this->assertFalse($items['foo']->isHit());
+        $this->assertEquals('value', $items['bar']->get());
+        $this->assertTrue($items['bar']->isHit());
+    }
+
+    /**
+     * @expectedException \Zend\Cache\Psr\InvalidArgumentException
+     */
+    public function testGetItemsInvalidKeyThrowsException()
+    {
+        $keys = ['ok'] + $this->getInvalidKeys();
+        $this->getAdapter()->getItems($keys);
+    }
+
+    public function testGetItemsRuntimeExceptionIsMiss()
+    {
+        $keys = ['foo', 'bar'];
+        $storage = $this->getStorageProphesy();
+        $storage->getItems(Argument::type('array'))
+            ->willThrow(Exception\RuntimeException::class);
+        $items = $this->getAdapter($storage)->getItems($keys);
+        $this->assertEquals(2, count($items));
+        foreach ($keys as $key) {
+            $this->assertFalse($items[$key]->isHit());
+        }
+    }
+
+    /**
+     * @expectedException \Zend\Cache\Psr\InvalidArgumentException
+     */
+    public function testGetItemsInvalidArgumentExceptionRethrown()
+    {
+        $storage = $this->getStorageProphesy();
+        $storage->getItems(Argument::type('array'))
+            ->willThrow(Exception\InvalidArgumentException::class);
+        $this->getAdapter($storage)->getItems(['foo', 'bar']);
+    }
+
+    public function testSaveItem()
+    {
+        $adapter = $this->getAdapter();
+        $item = $adapter->getItem('foo');
+        $item->set('bar');
+        $this->assertTrue($adapter->save($item));
+        $saved = $adapter->getItems(['foo']);
+        $this->assertEquals('bar', $saved['foo']->get());
+        $this->assertTrue($saved['foo']->isHit());
+    }
+
+    public function testSaveItemWithExpiration()
+    {
+        $storage = $this->getStorageProphesy()->reveal();
+        $adapter = new CacheItemPoolAdapter($storage);
+        $item = $adapter->getItem('foo');
+        $item->set('bar');
+        $item->expiresAfter(3600);
+        $this->assertTrue($adapter->save($item));
+        $saved = $adapter->getItems(['foo']);
+        $this->assertEquals('bar', $saved['foo']->get());
+        $this->assertTrue($saved['foo']->isHit());
+        // ensure original TTL not modified
+        $options = $storage->getOptions();
+        $this->assertEquals(0, $options->getTtl());
+    }
+
+    public function testExpiredItemNotSaved()
+    {
+        $storage = $this->getStorageProphesy()->reveal();
+        $adapter = new CacheItemPoolAdapter($storage);
+        $item = $adapter->getItem('foo');
+        $item->set('bar');
+        $item->expiresAfter(0);
+        $this->assertTrue($adapter->save($item));
+        $saved = $adapter->getItem('foo');
+        $this->assertFalse($saved->isHit());
+    }
+
+    /**
+     * @expectedException \Zend\Cache\Psr\InvalidArgumentException
+     */
+    public function testSaveForeignItemThrowsException()
+    {
+        $item = $this->prophesize(CacheItemInterface::class);
+        $this->getAdapter()->save($item->reveal());
+    }
+
+    public function testSaveItemRuntimeExceptionReturnsFalse()
+    {
+        $storage = $this->getStorageProphesy();
+        $storage->setItem(Argument::type('string'), Argument::any())
+            ->willThrow(Exception\RuntimeException::class);
+        $adapter = $this->getAdapter($storage);
+        $item = $adapter->getItem('foo');
+        $this->assertFalse($adapter->save($item));
+    }
+
+    /**
+     * @expectedException \Zend\Cache\Psr\InvalidArgumentException
+     */
+    public function testSaveItemInvalidArgumentExceptionRethrown()
+    {
+        $storage = $this->getStorageProphesy();
+        $storage->setItem(Argument::type('string'), Argument::any())
+            ->willThrow(Exception\InvalidArgumentException::class);
+        $adapter = $this->getAdapter($storage);
+        $item = $adapter->getItem('foo');
+        $adapter->save($item);
+    }
+
+    public function testHasItemReturnsTrue()
+    {
+        $adapter = $this->getAdapter();
+        $item = $adapter->getItem('foo');
+        $item->set('bar');
+        $adapter->save($item);
+        $this->assertTrue($adapter->hasItem('foo'));
+    }
+
+    public function testHasNonexistentItemReturnsFalse()
+    {
+        $this->assertFalse($this->getAdapter()->hasItem('foo'));
+    }
+
+    public function testHasDeferredItemReturnsTrue()
+    {
+        $adapter = $this->getAdapter();
+        $item = $adapter->getItem('foo');
+        $adapter->saveDeferred($item);
+        $this->assertTrue($adapter->hasItem('foo'));
+    }
+
+    public function testHasExpiredDeferredItemReturnsFalse()
+    {
+        $adapter = $this->getAdapter();
+        $item = $adapter->getItem('foo');
+        $item->set('bar');
+        $item->expiresAfter(0);
+        $adapter->saveDeferred($item);
+        $this->assertFalse($adapter->hasItem('foo'));
+    }
+
+    /**
+     * @dataProvider invalidKeyProvider
+     * @expectedException \Zend\Cache\Psr\InvalidArgumentException
+     */
+    public function testHasItemInvalidKeyThrowsException($key)
+    {
+        $this->getAdapter()->hasItem($key);
+    }
+
+    public function testHasItemRuntimeExceptionReturnsFalse()
+    {
+        $storage = $this->getStorageProphesy();
+        $storage->hasItem(Argument::type('string'))
+            ->willThrow(Exception\RuntimeException::class);
+        $this->assertFalse($this->getAdapter($storage)->hasItem('foo'));
+    }
+
+    /**
+     * @expectedException \Zend\Cache\Psr\InvalidArgumentException
+     */
+    public function testHasItemInvalidArgumentExceptionRethrown()
+    {
+        $storage = $this->getStorageProphesy();
+        $storage->hasItem(Argument::type('string'))
+            ->willThrow(Exception\InvalidArgumentException::class);
+        $this->getAdapter($storage)->hasItem('foo');
+    }
+
+    public function testClearReturnsTrue()
+    {
+        $adapter = $this->getAdapter();
+        $item = $adapter->getItem('foo');
+        $item->set('bar');
+        $adapter->save($item);
+        $this->assertTrue($adapter->clear());
+    }
+
+    public function testClearEmptyReturnsTrue()
+    {
+        $this->assertTrue($this->getAdapter()->clear());
+    }
+
+    public function testClearDeferred()
+    {
+        $adapter = $this->getAdapter();
+        $item = $adapter->getItem('foo');
+        $adapter->saveDeferred($item);
+        $adapter->clear();
+        $this->assertFalse($adapter->hasItem('foo'));
+    }
+
+    public function testClearRuntimeExceptionReturnsFalse()
+    {
+        $storage = $this->getStorageProphesy();
+        $storage->flush()
+            ->willThrow(Exception\RuntimeException::class);
+        $this->assertFalse($this->getAdapter($storage)->clear());
+    }
+
+    public function testClearByNamespaceReturnsTrue()
+    {
+        $storage = $this->getStorageProphesy(false, ['namespace' => 'zfcache']);
+        $storage->clearByNamespace(Argument::any())->willReturn(true)->shouldBeCalled();
+        $this->assertTrue($this->getAdapter($storage)->clear());
+    }
+
+    public function testClearByEmptyNamespaceCallsFlush()
+    {
+        $storage = $this->getStorageProphesy(false, ['namespace' => '']);
+        $storage->flush()->willReturn(true)->shouldBeCalled();
+        $this->assertTrue($this->getAdapter($storage)->clear());
+    }
+
+    public function testClearByNamespaceRuntimeExceptionReturnsFalse()
+    {
+        $storage = $this->getStorageProphesy(false, ['namespace' => 'zfcache']);
+        $storage->clearByNamespace(Argument::any())
+            ->willThrow(Exception\RuntimeException::class)
+            ->shouldBeCalled();
+        $this->assertFalse($this->getAdapter($storage)->clear());
+    }
+
+    public function testDeleteItemReturnsTrue()
+    {
+        $this->assertTrue($this->getAdapter()->deleteItem('foo'));
+    }
+
+    public function testDeleteDeferredItem()
+    {
+        $adapter = $this->getAdapter();
+        $item = $adapter->getItem('foo');
+        $adapter->saveDeferred($item);
+        $adapter->deleteItem('foo');
+        $this->assertFalse($adapter->hasItem('foo'));
+    }
+
+    /**
+     * @dataProvider invalidKeyProvider
+     * @expectedException \Zend\Cache\Psr\InvalidArgumentException
+     */
+    public function testDeleteItemInvalidKeyThrowsException($key)
+    {
+        $this->getAdapter()->deleteItem($key);
+    }
+
+    public function testDeleteItemRuntimeExceptionReturnsFalse()
+    {
+        $storage = $this->getStorageProphesy();
+        $storage->removeItems(Argument::type('array'))
+            ->willThrow(Exception\RuntimeException::class);
+        $this->assertFalse($this->getAdapter($storage)->deleteItem('foo'));
+    }
+
+    /**
+     * @expectedException \Zend\Cache\Psr\InvalidArgumentException
+     */
+    public function testDeleteItemInvalidArgumentExceptionRethrown()
+    {
+        $storage = $this->getStorageProphesy();
+        $storage->removeItems(Argument::type('array'))
+            ->willThrow(Exception\InvalidArgumentException::class);
+        $this->getAdapter($storage)->deleteItem('foo');
+    }
+
+    public function testDeleteItemsReturnsTrue()
+    {
+        $this->assertTrue($this->getAdapter()->deleteItems(['foo', 'bar', 'baz']));
+    }
+
+    public function testDeleteDeferredItems()
+    {
+        $keys = ['foo', 'bar', 'baz'];
+        $adapter = $this->getAdapter();
+        foreach ($keys as $key) {
+            $item = $adapter->getItem($key);
+            $adapter->saveDeferred($item);
+        }
+        $keys = ['foo', 'bar'];
+        $adapter->deleteItems($keys);
+        foreach ($keys as $key) {
+            $this->assertFalse($adapter->hasItem($key));
+        }
+        $this->assertTrue($adapter->hasItem('baz'));
+    }
+
+    /**
+     * @expectedException \Zend\Cache\Psr\InvalidArgumentException
+     */
+    public function testDeleteItemsInvalidKeyThrowsException()
+    {
+        $keys = ['ok'] + $this->getInvalidKeys();
+        $this->getAdapter()->deleteItems($keys);
+    }
+
+    public function testDeleteItemsRuntimeExceptionReturnsFalse()
+    {
+        $storage = $this->getStorageProphesy();
+        $storage->removeItems(Argument::type('array'))
+            ->willThrow(Exception\RuntimeException::class);
+        $this->assertFalse($this->getAdapter($storage)->deleteItems(['foo', 'bar', 'baz']));
+    }
+
+    /**
+     * @expectedException \Zend\Cache\Psr\InvalidArgumentException
+     */
+    public function testDeleteItemsInvalidArgumentExceptionRethrown()
+    {
+        $storage = $this->getStorageProphesy();
+        $storage->removeItems(Argument::type('array'))
+            ->willThrow(Exception\InvalidArgumentException::class);
+        $this->getAdapter($storage)->deleteItems(['foo', 'bar', 'baz']);
+    }
+
+    public function testSaveDeferredReturnsTrue()
+    {
+        $adapter = $this->getAdapter();
+        $item = $adapter->getItem('foo');
+        $this->assertTrue($adapter->saveDeferred($item));
+    }
+
+    /**
+     * @expectedException \Zend\Cache\Psr\InvalidArgumentException
+     */
+    public function testSaveDeferredForeignItemThrowsException()
+    {
+        $item = $this->prophesize(CacheItemInterface::class);
+        $this->getAdapter()->saveDeferred($item->reveal());
+    }
+
+    public function testCommitReturnsTrue()
+    {
+        $adapter = $this->getAdapter();
+        $item = $adapter->getItem('foo');
+        $adapter->saveDeferred($item);
+        $this->assertTrue($adapter->commit());
+    }
+
+    public function testCommitEmptyReturnsTrue()
+    {
+        $this->assertTrue($this->getAdapter()->commit());
+    }
+
+    public function testCommitRuntimeExceptionReturnsFalse()
+    {
+        $storage = $this->getStorageProphesy();
+        $storage->setItem(Argument::type('string'), Argument::any())
+            ->willThrow(Exception\RuntimeException::class);
+        $adapter = $this->getAdapter($storage);
+        $item = $adapter->getItem('foo');
+        $adapter->saveDeferred($item);
+        $this->assertFalse($adapter->commit());
+    }
+
+    public function invalidKeyProvider()
+    {
+        return array_map(function ($v) { return [$v]; }, $this->getInvalidKeys());
+    }
+
+    private function getInvalidKeys()
+    {
+        return [
+            'key{',
+            'key}',
+            'key(',
+            'key)',
+            'key/',
+            'key\\',
+            'key@',
+            'key:',
+            new \stdClass()
+        ];
+    }
+
+    /**
+     * @param Prophesy $storage
+     * @return CacheItemPoolAdapter
+     */
+    private function getAdapter($storage = null)
+    {
+        if (!$storage) {
+            $storage = $this->getStorageProphesy();
+        }
+        return new CacheItemPoolAdapter($storage->reveal());
+    }
+}

--- a/test/Psr/CacheItemPoolAdapterTest.php
+++ b/test/Psr/CacheItemPoolAdapterTest.php
@@ -6,6 +6,7 @@
  * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
+
 namespace ZendTest\Cache;
 
 use PHPUnit_Framework_TestCase as TestCase;

--- a/test/Psr/CacheItemTest.php
+++ b/test/Psr/CacheItemTest.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/).
+ *
+ * @link      http://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+namespace ZendTest\Cache\Psr;
+
+use DateInterval;
+use DateTime;
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Cache\Psr\CacheItem;
+
+class CacheItemTest extends TestCase
+{
+    private $tz;
+
+    protected function setUp()
+    {
+        // set non-UTC timezone
+        $this->tz = date_default_timezone_get();
+        date_default_timezone_set('America/Vancouver');
+    }
+
+    protected function tearDown()
+    {
+        date_default_timezone_set($this->tz);
+    }
+
+    public function testConstructorIsHit()
+    {
+        $item = new CacheItem('key', 'value', true);
+        $this->assertEquals('key', $item->getKey());
+        $this->assertEquals('value', $item->get());
+        $this->assertTrue($item->isHit());
+    }
+
+    public function testConstructorIsNotHit()
+    {
+        $item = new CacheItem('key', 'value', false);
+        $this->assertEquals('key', $item->getKey());
+        $this->assertNull($item->get());
+        $this->assertFalse($item->isHit());
+    }
+
+    public function testSet()
+    {
+        $item = new CacheItem('key', 'value', true);
+        $return = $item->set('value2');
+        $this->assertEquals($item, $return);
+        $this->assertEquals('value2', $item->get());
+    }
+
+    public function testExpiresAtDateTime()
+    {
+        $item = new CacheItem('key', 'value', true);
+        $dateTime = new DateTime('+5 seconds');
+        $return = $item->expiresAt($dateTime);
+        $this->assertEquals($item, $return);
+        $this->assertEquals(5, $item->getTtl());
+    }
+
+    public function testExpireAtNull()
+    {
+        $item = new CacheItem('key', 'value', true);
+        $return = $item->expiresAt(null);
+        $this->assertEquals($item, $return);
+        $this->assertNull($item->getTtl());
+    }
+
+    /**
+     * @expectedException \Zend\Cache\Psr\InvalidArgumentException
+     */
+    public function testExpireAtInvalidThrowsException()
+    {
+        $item = new CacheItem('key', 'value', true);
+        $item->expiresAt('foo');
+    }
+
+    public function testExpiresAfterInt()
+    {
+        $item = new CacheItem('key', 'value', true);
+        $return = $item->expiresAfter(3600);
+        $this->assertEquals($item, $return);
+        $this->assertEquals(3600, $item->getTtl());
+    }
+
+    public function testExpiresAfterInterval()
+    {
+        $item = new CacheItem('key', 'value', true);
+        $interval = new DateInterval('PT1H');
+        $return = $item->expiresAfter($interval);
+        $this->assertEquals($item, $return);
+        $this->assertEquals(3600, $item->getTtl());
+    }
+
+    public function testExpiresAfterNull()
+    {
+        $item = new CacheItem('key', 'value', true);
+        $item->expiresAfter(null);
+        $this->assertNull($item->getTtl());
+    }
+
+    /**
+     * @expectedException \Zend\Cache\Psr\InvalidArgumentException
+     */
+    public function testExpiresAfterInvalidThrowsException()
+    {
+        $item = new CacheItem('key', 'value', true);
+        $item->expiresAfter([]);
+    }
+}

--- a/test/Psr/CacheItemTest.php
+++ b/test/Psr/CacheItemTest.php
@@ -6,6 +6,7 @@
  * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
+
 namespace ZendTest\Cache\Psr;
 
 use DateInterval;

--- a/test/Psr/DbaIntegrationTest.php
+++ b/test/Psr/DbaIntegrationTest.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * @author matt
- * @copyright 2015 Claritum Limited
- * @license Commercial
+ * Zend Framework (http://framework.zend.com/).
+ *
+ * @link      http://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
 namespace ZendTest\Cache\Psr;

--- a/test/Psr/DbaIntegrationTest.php
+++ b/test/Psr/DbaIntegrationTest.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @author matt
+ * @copyright 2015 Claritum Limited
+ * @license Commercial
+ */
+
+namespace ZendTest\Cache\Psr;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Cache\Psr\CacheItemPoolAdapter;
+use Zend\Cache\StorageFactory;
+
+class DbaIntegrationTest extends TestCase
+{
+    /**
+     * @expectedException \Zend\Cache\Psr\CacheException
+     */
+    public function testAdapterNotSupported()
+    {
+        $storage = StorageFactory::factory([
+            'adapter' => [
+                'name'    => 'dba',
+                'options' => [],
+            ],
+        ]);
+
+        new CacheItemPoolAdapter($storage);
+    }
+}

--- a/test/Psr/FilesystemIntegrationTest.php
+++ b/test/Psr/FilesystemIntegrationTest.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * @author matt
- * @copyright 2015 Claritum Limited
- * @license Commercial
+ * Zend Framework (http://framework.zend.com/).
+ *
+ * @link      http://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
 namespace ZendTest\Cache\Psr;

--- a/test/Psr/FilesystemIntegrationTest.php
+++ b/test/Psr/FilesystemIntegrationTest.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @author matt
+ * @copyright 2015 Claritum Limited
+ * @license Commercial
+ */
+
+namespace ZendTest\Cache\Psr;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Cache\Psr\CacheItemPoolAdapter;
+use Zend\Cache\StorageFactory;
+
+class FilesystemIntegrationTest extends TestCase
+{
+    /**
+     * @expectedException \Zend\Cache\Psr\CacheException
+     */
+    public function testAdapterNotSupported()
+    {
+        $storage = StorageFactory::factory([
+            'adapter' => [
+                'name'    => 'filesystem',
+                'options' => [],
+            ],
+        ]);
+
+        new CacheItemPoolAdapter($storage);
+    }
+}

--- a/test/Psr/MemcacheIntegrationTest.php
+++ b/test/Psr/MemcacheIntegrationTest.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/).
+ *
+ * @link      http://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+namespace ZendTest\Cache\Psr;
+
+use Cache\IntegrationTests\CachePoolTest;
+use Zend\Cache\Psr\CacheItemPoolAdapter;
+use Zend\Cache\Storage\Adapter\Memcache;
+use Zend\Cache\StorageFactory;
+
+/**
+ * @require extension memcache
+ */
+class MemcacheIntegrationTest extends CachePoolTest
+{
+    private $tz;
+
+    /**
+     * @var Memcache
+     */
+    private $storage;
+
+    protected function setUp()
+    {
+        if (!getenv('TESTS_ZEND_CACHE_MEMCACHE_ENABLED')) {
+            $this->markTestSkipped('Enable TESTS_ZEND_CACHE_MEMCACHE_ENABLED to run this test');
+        }
+
+        if (version_compare('2.0.0', phpversion('memcache')) > 0) {
+            $this->markTestSkipped("Missing ext/memcache version >= 2.0.0");
+        }
+
+        // set non-UTC timezone
+        $this->tz = date_default_timezone_get();
+        date_default_timezone_set('America/Vancouver');
+
+        parent::setUp();
+    }
+
+    protected function tearDown()
+    {
+        date_default_timezone_set($this->tz);
+
+        if ($this->storage) {
+            $this->storage->flush();
+        }
+
+        parent::tearDown();
+    }
+
+    public function createCachePool()
+    {
+        $host = getenv('TESTS_ZEND_CACHE_MEMCACHE_HOST');
+        $port = getenv('TESTS_ZEND_CACHE_MEMCACHE_PORT');
+
+        $options = [
+            'resource_id' => __CLASS__
+        ];
+        if ($host && $port) {
+            $options['servers'] = [[$host, $port]];
+        } elseif ($host) {
+            $options['servers'] = [[$host]];
+        }
+
+        $adapter = StorageFactory::factory([
+            'adapter' => [
+                'name'    => 'memcache',
+                'options' => $options,
+            ],
+        ]);
+        return new CacheItemPoolAdapter($adapter);
+    }
+}

--- a/test/Psr/MemcacheIntegrationTest.php
+++ b/test/Psr/MemcacheIntegrationTest.php
@@ -6,6 +6,7 @@
  * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
+
 namespace ZendTest\Cache\Psr;
 
 use Cache\IntegrationTests\CachePoolTest;

--- a/test/Psr/MemcachedIntegrationTest.php
+++ b/test/Psr/MemcachedIntegrationTest.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/).
+ *
+ * @link      http://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+namespace ZendTest\Cache\Psr;
+
+use Cache\IntegrationTests\CachePoolTest;
+use Zend\Cache\Psr\CacheItemPoolAdapter;
+use Zend\Cache\Storage\Adapter\Memcached;
+use Zend\Cache\StorageFactory;
+
+/**
+ * @require extension memcached
+ */
+class MemcachedIntegrationTest extends CachePoolTest
+{
+    private $tz;
+
+    /**
+     * @var Memcached
+     */
+    private $storage;
+
+    protected function setUp()
+    {
+        if (!getenv('TESTS_ZEND_CACHE_MEMCACHED_ENABLED')) {
+            $this->markTestSkipped('Enable TESTS_ZEND_CACHE_MEMCACHED_ENABLED to run this test');
+        }
+
+        // set non-UTC timezone
+        $this->tz = date_default_timezone_get();
+        date_default_timezone_set('America/Vancouver');
+
+        parent::setUp();
+    }
+
+    protected function tearDown()
+    {
+        date_default_timezone_set($this->tz);
+
+        if ($this->storage) {
+            $this->storage->flush();
+        }
+
+        parent::tearDown();
+    }
+
+    public function createCachePool()
+    {
+        $host = getenv('TESTS_ZEND_CACHE_MEMCACHED_HOST');
+        $port = getenv('TESTS_ZEND_CACHE_MEMCACHED_PORT');
+
+        $options = [
+            'resource_id' => __CLASS__
+        ];
+        if ($host && $port) {
+            $options['servers'] = [[$host, $port]];
+        } elseif ($host) {
+            $options['servers'] = [[$host]];
+        }
+
+        $this->storage = StorageFactory::factory([
+            'adapter' => [
+                'name'    => 'memcached',
+                'options' => $options
+            ],
+        ]);
+
+        $options = $this->storage->getOptions();
+        $servers = $options->getServers();
+
+        return new CacheItemPoolAdapter($this->storage);
+    }
+}

--- a/test/Psr/MemcachedIntegrationTest.php
+++ b/test/Psr/MemcachedIntegrationTest.php
@@ -6,6 +6,7 @@
  * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
+
 namespace ZendTest\Cache\Psr;
 
 use Cache\IntegrationTests\CachePoolTest;

--- a/test/Psr/MemoryIntegrationTest.php
+++ b/test/Psr/MemoryIntegrationTest.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * @author matt
- * @copyright 2015 Claritum Limited
- * @license Commercial
+ * Zend Framework (http://framework.zend.com/).
+ *
+ * @link      http://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
 namespace ZendTest\Cache\Psr;

--- a/test/Psr/MemoryIntegrationTest.php
+++ b/test/Psr/MemoryIntegrationTest.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @author matt
+ * @copyright 2015 Claritum Limited
+ * @license Commercial
+ */
+
+namespace ZendTest\Cache\Psr;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Cache\Psr\CacheItemPoolAdapter;
+use Zend\Cache\StorageFactory;
+
+class MemoryIntegrationTest extends TestCase
+{
+    /**
+     * @expectedException \Zend\Cache\Psr\CacheException
+     */
+    public function testAdapterNotSupported()
+    {
+        $storage = StorageFactory::factory([
+            'adapter' => [
+                'name'    => 'memory',
+                'options' => [],
+            ],
+        ]);
+
+        new CacheItemPoolAdapter($storage);
+    }
+}

--- a/test/Psr/MockStorageTrait.php
+++ b/test/Psr/MockStorageTrait.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/).
+ *
+ * @link      http://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+namespace ZendTest\Cache\Psr;
+
+use DateInterval;
+use DateTime;
+use DateTimeZone;
+use Prophecy\Argument;
+use Zend\Cache\Storage\Adapter\AbstractAdapter;
+use Zend\Cache\Storage\Adapter\AdapterOptions;
+use Zend\Cache\Storage\Capabilities;
+use Zend\Cache\Storage\ClearByNamespaceInterface;
+use Zend\Cache\Storage\FlushableInterface;
+use Zend\Cache\Storage\StorageInterface;
+use Zend\EventManager\EventManager;
+
+trait MockStorageTrait
+{
+    protected $defaultCapabilities = [
+        'staticTtl' => true,
+        'minTtl' => 1,
+        'supportedDatatypes' => [
+            'NULL'     => true,
+            'boolean'  => true,
+            'integer'  => true,
+            'double'   => true,
+            'string'   => true,
+            'array'    => true,
+            'object'   => 'object',
+            'resource' => false,
+        ],
+    ];
+
+    protected function getStorageProphesy($capabilities = false, $options = false, $class = StorageInterface::class)
+    {
+        if ($capabilities === false) {
+            $capabilities = $this->defaultCapabilities;
+        }
+        if ($options === false) {
+            $options = [];
+        }
+
+        // cached items
+        $items = [];
+
+        $storage = $this->prophesize($class);
+        $storage->willImplement(FlushableInterface::class);
+        if (array_key_exists('namespace', $options)) {
+            $storage->willImplement(ClearByNamespaceInterface::class);
+        }
+        if ($class == AbstractAdapter::class) {
+            $eventManager = new EventManager();
+            $storage->getEventManager()->willReturn($eventManager);
+        }
+        $storage->getCapabilities()
+            ->will(function () use ($capabilities) {
+                return new Capabilities(
+                    $this->reveal(),
+                    new \stdClass(),
+                    $capabilities
+                );
+            });
+        $storage->getOptions()
+            ->will(function () use ($options) {
+                $adapterOptions = new AdapterOptions($options);
+                $this->getOptions()->willReturn($adapterOptions);
+                return $adapterOptions;
+            });
+
+        $storage->hasItem(Argument::type('string'))
+            ->will(function ($args) use (&$items) {
+                $key = $args[0];
+                if (! isset($items[$key])) {
+                    return false;
+                }
+                return $items[$key]['ttd'] > new DateTime('now', new DateTimeZone('UTC'));
+            });
+        $storage->getItem(Argument::type('string'), Argument::any())
+            ->will(function ($args) use (&$items) {
+                $key = $args[0];
+                if (isset($items[$key]) && $items[$key]['ttd'] > new DateTime('now', new DateTimeZone('UTC'))) {
+                    return $items[$key]['value'];
+                }
+                return;
+            });
+        $storage->getItems(Argument::type('array'))
+            ->will(function ($args) use (&$items) {
+                $found = [];
+                foreach (array_intersect_key($items, array_flip($args[0])) as $key => $item) {
+                    if ($item['ttd'] > new DateTime('now', new DateTimeZone('UTC'))) {
+                        $found[$key] = $item['value'];
+                    }
+                }
+                return $found;
+            });
+        $storage->setItem(Argument::type('string'), Argument::any())
+            ->will(function ($args) use (&$items) {
+                $key = $args[0];
+                $ttl = $this->reveal()->getOptions()->getTtl();
+                if (!$ttl) {
+                    $ttl = 3600;
+                }
+                $ttd = (new DateTime('now', new DateTimeZone('UTC')))->add(new DateInterval('PT' . $ttl . 'S'));
+                $items[$key] = ['ttd' => $ttd, 'value' => $args[1]];
+                return true;
+            });
+        $storage->flush()
+            ->will(function () use (&$items) {
+                $items = [];
+                return true;
+            });
+        $storage->removeItems(Argument::type('array'))
+            ->will(function ($args) use (&$items) {
+                $items = array_diff_key($items, array_flip($args[0]));
+                return true;
+            });
+
+        return $storage;
+    }
+}

--- a/test/Psr/MockStorageTrait.php
+++ b/test/Psr/MockStorageTrait.php
@@ -6,6 +6,7 @@
  * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
+
 namespace ZendTest\Cache\Psr;
 
 use DateInterval;

--- a/test/Psr/MongoDbIntegrationTest.php
+++ b/test/Psr/MongoDbIntegrationTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/).
+ *
+ * @link      http://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+namespace ZendTest\Cache\Psr;
+
+use Cache\IntegrationTests\CachePoolTest;
+use Zend\Cache\Psr\CacheItemPoolAdapter;
+use Zend\Cache\Storage\Adapter\MongoDb;
+use Zend\Cache\StorageFactory;
+
+class MongoDbIntegrationTest extends CachePoolTest
+{
+    private $tz;
+
+    /**
+     * @var MongoDb
+     */
+    private $storage;
+
+    protected function setUp()
+    {
+        if (!getenv('TESTS_ZEND_CACHE_MONGODB_ENABLED')) {
+            $this->markTestSkipped('Enable TESTS_ZEND_CACHE_MONGODB_ENABLED to run this test');
+        }
+
+        if (!extension_loaded('mongo') || !class_exists('\Mongo') || !class_exists('\MongoClient')) {
+            // Allow tests to run if Mongo extension is loaded, or we have a polyfill in place
+            $this->markTestSkipped("Mongo extension is not loaded");
+        }
+
+        // set non-UTC timezone
+        $this->tz = date_default_timezone_get();
+        date_default_timezone_set('America/Vancouver');
+
+        parent::setUp();
+    }
+
+    protected function tearDown()
+    {
+        date_default_timezone_set($this->tz);
+
+        if ($this->storage) {
+            $this->storage->flush();
+        }
+
+        parent::tearDown();
+    }
+
+    public function createCachePool()
+    {
+        $options = [
+            'server'     => getenv('TESTS_ZEND_CACHE_MONGODB_CONNECTSTRING'),
+            'database'   => getenv('TESTS_ZEND_CACHE_MONGODB_DATABASE'),
+            'collection' => getenv('TESTS_ZEND_CACHE_MONGODB_COLLECTION'),
+        ];
+        $this->storage = StorageFactory::factory([
+            'adapter' => [
+                'name'    => 'mongodb',
+                'options' => $options,
+            ],
+        ]);
+
+        return new CacheItemPoolAdapter($this->storage);
+    }
+}

--- a/test/Psr/MongoDbIntegrationTest.php
+++ b/test/Psr/MongoDbIntegrationTest.php
@@ -6,6 +6,7 @@
  * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
+
 namespace ZendTest\Cache\Psr;
 
 use Cache\IntegrationTests\CachePoolTest;

--- a/test/Psr/RedisIntegrationTest.php
+++ b/test/Psr/RedisIntegrationTest.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/).
+ *
+ * @link      http://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+namespace ZendTest\Cache\Psr;
+
+use Cache\IntegrationTests\CachePoolTest;
+use Zend\Cache\Psr\CacheItemPoolAdapter;
+use Zend\Cache\Storage\Adapter\Redis;
+use Zend\Cache\StorageFactory;
+
+class RedisIntegrationTest extends CachePoolTest
+{
+    private $tz;
+
+    /**
+     * @var Redis
+     */
+    private $storage;
+
+    protected function setUp()
+    {
+        if (!getenv('TESTS_ZEND_CACHE_REDIS_ENABLED')) {
+            $this->markTestSkipped('Enable TESTS_ZEND_CACHE_REDIS_ENABLED to run this test');
+        }
+
+        if (!extension_loaded('redis')) {
+            $this->markTestSkipped("Redis extension is not loaded");
+        }
+
+        // set non-UTC timezone
+        $this->tz = date_default_timezone_get();
+        date_default_timezone_set('America/Vancouver');
+
+        parent::setUp();
+    }
+
+    protected function tearDown()
+    {
+        date_default_timezone_set($this->tz);
+
+        if ($this->storage) {
+            $this->storage->flush();
+        }
+
+        parent::tearDown();
+    }
+
+    public function createCachePool()
+    {
+        $options = ['resource_id' => __CLASS__];
+
+        if (getenv('TESTS_ZEND_CACHE_REDIS_HOST') && getenv('TESTS_ZEND_CACHE_REDIS_PORT')) {
+            $options['server'] = [getenv('TESTS_ZEND_CACHE_REDIS_HOST'), getenv('TESTS_ZEND_CACHE_REDIS_PORT')];
+        } elseif (getenv('TESTS_ZEND_CACHE_REDIS_HOST')) {
+            $options['server'] = [getenv('TESTS_ZEND_CACHE_REDIS_HOST')];
+        }
+
+        if (getenv('TESTS_ZEND_CACHE_REDIS_DATABASE')) {
+            $options['database'] = getenv('TESTS_ZEND_CACHE_REDIS_DATABASE');
+        }
+
+        if (getenv('TESTS_ZEND_CACHE_REDIS_PASSWORD')) {
+            $options['password'] = getenv('TESTS_ZEND_CACHE_REDIS_PASSWORD');
+        }
+
+        $this->storage = StorageFactory::factory([
+            'adapter' => [
+                'name'    => 'redis',
+                'options' => $options,
+            ],
+        ]);
+        return new CacheItemPoolAdapter($this->storage);
+    }
+}

--- a/test/Psr/RedisIntegrationTest.php
+++ b/test/Psr/RedisIntegrationTest.php
@@ -6,6 +6,7 @@
  * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
+
 namespace ZendTest\Cache\Psr;
 
 use Cache\IntegrationTests\CachePoolTest;

--- a/test/Psr/SessionIntegrationTest.php
+++ b/test/Psr/SessionIntegrationTest.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * @author matt
- * @copyright 2015 Claritum Limited
- * @license Commercial
+ * Zend Framework (http://framework.zend.com/).
+ *
+ * @link      http://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
 namespace ZendTest\Cache\Psr;

--- a/test/Psr/SessionIntegrationTest.php
+++ b/test/Psr/SessionIntegrationTest.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @author matt
+ * @copyright 2015 Claritum Limited
+ * @license Commercial
+ */
+
+namespace ZendTest\Cache\Psr;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Cache\Psr\CacheItemPoolAdapter;
+use Zend\Cache\StorageFactory;
+
+class SessionIntegrationTest extends TestCase
+{
+    /**
+     * @expectedException \Zend\Cache\Psr\CacheException
+     */
+    public function testAdapterNotSupported()
+    {
+        $storage = StorageFactory::factory([
+            'adapter' => [
+                'name'    => 'session',
+                'options' => [],
+            ],
+        ]);
+
+        new CacheItemPoolAdapter($storage);
+    }
+}

--- a/test/Psr/WinCacheIntegrationTest.php
+++ b/test/Psr/WinCacheIntegrationTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/).
+ *
+ * @link      http://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+namespace ZendTest\Cache\Psr;
+
+use Cache\IntegrationTests\CachePoolTest;
+use Zend\Cache\Psr\CacheItemPoolAdapter;
+use Zend\Cache\Storage\Adapter\WinCache;
+use Zend\Cache\StorageFactory;
+
+/**
+ * @requires extension wincache
+ */
+class WinCacheIntegrationTest extends CachePoolTest
+{
+    private $tz;
+
+    /**
+     * @var WinCache
+     */
+    private $storage;
+
+    protected function setUp()
+    {
+        if (!getenv('TESTS_ZEND_CACHE_WINCACHE_ENABLED')) {
+            $this->markTestSkipped('Enable TESTS_ZEND_CACHE_WINCACHE_ENABLED to run this test');
+        }
+
+        $enabled = ini_get('wincache.ucenabled');
+        if (PHP_SAPI == 'cli') {
+            $enabled = $enabled && (bool) ini_get('wincache.enablecli');
+        }
+
+        if (!$enabled) {
+            $this->markTestSkipped("WinCache is disabled - see 'wincache.ucenabled' and 'wincache.enablecli'");
+        }
+
+        // set non-UTC timezone
+        $this->tz = date_default_timezone_get();
+        date_default_timezone_set('America/Vancouver');
+
+        parent::setUp();
+    }
+
+    protected function tearDown()
+    {
+        date_default_timezone_set($this->tz);
+
+        if ($this->storage) {
+            $this->storage->flush();
+        }
+
+        parent::tearDown();
+    }
+
+    public function createCachePool()
+    {
+        $this->storage = StorageFactory::factory([
+            'adapter' => [
+                'name'    => 'xcache',
+                'options' => [],
+            ],
+        ]);
+        return new CacheItemPoolAdapter($this->storage);
+    }
+}

--- a/test/Psr/WinCacheIntegrationTest.php
+++ b/test/Psr/WinCacheIntegrationTest.php
@@ -6,6 +6,7 @@
  * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
+
 namespace ZendTest\Cache\Psr;
 
 use Cache\IntegrationTests\CachePoolTest;

--- a/test/Psr/XCacheIntegrationTest.php
+++ b/test/Psr/XCacheIntegrationTest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/).
+ *
+ * @link      http://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+namespace ZendTest\Cache\Psr;
+
+use Cache\IntegrationTests\CachePoolTest;
+use Zend\Cache\Exception\ExtensionNotLoadedException;
+use Zend\Cache\Psr\CacheItemPoolAdapter;
+use Zend\Cache\Storage\Adapter\XCache;
+use Zend\Cache\StorageFactory;
+
+/**
+ * @requires extension xcache
+ */
+class XCacheIntegrationTest extends CachePoolTest
+{
+    private $tz;
+
+    /**
+     * @var XCache
+     */
+    private $storage;
+
+    protected function setUp()
+    {
+        if (!getenv('TESTS_ZEND_CACHE_XCACHE_ENABLED')) {
+            $this->markTestSkipped('Enable TESTS_ZEND_CACHE_XCACHE_ENABLED to run this test');
+        }
+
+        if ((int)ini_get('xcache.var_size') <= 0) {
+            $this->markTestSkipped("ext/xcache is disabled - see 'xcache.var_size'");
+        }
+
+        if (PHP_SAPI == 'cli') {
+            // this will throw exception for xcache < 3.1.0
+            try {
+                new XCache();
+            } catch (ExtensionNotLoadedException $e) {
+                $this->markTestSkipped($e->getMessage());
+            }
+        }
+
+        // set non-UTC timezone
+        $this->tz = date_default_timezone_get();
+        date_default_timezone_set('America/Vancouver');
+
+        parent::setUp();
+    }
+
+    protected function tearDown()
+    {
+        date_default_timezone_set($this->tz);
+
+        if ($this->storage) {
+            $this->storage->flush();
+        }
+
+        parent::tearDown();
+    }
+
+    public function createCachePool()
+    {
+        $options = [
+            'admin_auth' => getenv('TESTS_ZEND_CACHE_XCACHE_ADMIN_AUTH') ? : false,
+            'admin_user' => getenv('TESTS_ZEND_CACHE_XCACHE_ADMIN_USER') ? : '',
+            'admin_pass' => getenv('TESTS_ZEND_CACHE_XCACHE_ADMIN_PASS') ? : '',
+        ];
+
+        $this->storage = StorageFactory::factory([
+            'adapter' => [
+                'name'    => 'xcache',
+                'options' => $options,
+            ],
+        ]);
+        return new CacheItemPoolAdapter($this->storage);
+    }
+}

--- a/test/Psr/XCacheIntegrationTest.php
+++ b/test/Psr/XCacheIntegrationTest.php
@@ -6,77 +6,31 @@
  * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
+
 namespace ZendTest\Cache\Psr;
 
-use Cache\IntegrationTests\CachePoolTest;
-use Zend\Cache\Exception\ExtensionNotLoadedException;
+use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Cache\Psr\CacheItemPoolAdapter;
-use Zend\Cache\Storage\Adapter\XCache;
 use Zend\Cache\StorageFactory;
 
 /**
  * @requires extension xcache
  */
-class XCacheIntegrationTest extends CachePoolTest
+class XCacheIntegrationTest extends TestCase
 {
-    private $tz;
-
     /**
-     * @var XCache
+     * XCache has useRequestTime = true
+     * @expectedException \Zend\Cache\Psr\CacheException
      */
-    private $storage;
-
-    protected function setUp()
+    public function testAdapterNotSupported()
     {
-        if (!getenv('TESTS_ZEND_CACHE_XCACHE_ENABLED')) {
-            $this->markTestSkipped('Enable TESTS_ZEND_CACHE_XCACHE_ENABLED to run this test');
-        }
-
-        if ((int)ini_get('xcache.var_size') <= 0) {
-            $this->markTestSkipped("ext/xcache is disabled - see 'xcache.var_size'");
-        }
-
-        if (PHP_SAPI == 'cli') {
-            // this will throw exception for xcache < 3.1.0
-            try {
-                new XCache();
-            } catch (ExtensionNotLoadedException $e) {
-                $this->markTestSkipped($e->getMessage());
-            }
-        }
-
-        // set non-UTC timezone
-        $this->tz = date_default_timezone_get();
-        date_default_timezone_set('America/Vancouver');
-
-        parent::setUp();
-    }
-
-    protected function tearDown()
-    {
-        date_default_timezone_set($this->tz);
-
-        if ($this->storage) {
-            $this->storage->flush();
-        }
-
-        parent::tearDown();
-    }
-
-    public function createCachePool()
-    {
-        $options = [
-            'admin_auth' => getenv('TESTS_ZEND_CACHE_XCACHE_ADMIN_AUTH') ? : false,
-            'admin_user' => getenv('TESTS_ZEND_CACHE_XCACHE_ADMIN_USER') ? : '',
-            'admin_pass' => getenv('TESTS_ZEND_CACHE_XCACHE_ADMIN_PASS') ? : '',
-        ];
-
-        $this->storage = StorageFactory::factory([
+        $storage = StorageFactory::factory([
             'adapter' => [
                 'name'    => 'xcache',
-                'options' => $options,
+                'options' => [],
             ],
         ]);
-        return new CacheItemPoolAdapter($this->storage);
+
+        new CacheItemPoolAdapter($storage);
     }
 }

--- a/test/Psr/ZendServerDiskIntegrationTest.php
+++ b/test/Psr/ZendServerDiskIntegrationTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/).
+ *
+ * @link      http://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+namespace ZendTest\Cache\Psr;
+
+use Cache\IntegrationTests\CachePoolTest;
+use Zend\Cache\Psr\CacheItemPoolAdapter;
+use Zend\Cache\StorageFactory;
+
+class ZendServerDiskIntegrationTest extends CachePoolTest
+{
+    private $tz;
+
+    protected function setUp()
+    {
+        if (!getenv('TESTS_ZEND_CACHE_ZEND_SERVER_ENABLED')) {
+            $this->markTestSkipped('Enable TESTS_ZEND_CACHE_ZEND_SERVER_ENABLED to run this test');
+        }
+
+        if (!function_exists('zend_disk_cache_store') || PHP_SAPI == 'cli') {
+            $this->markTestSkipped("Missing 'zend_disk_cache_*' functions or running from SAPI 'cli'");
+        }
+
+        // set non-UTC timezone
+        $this->tz = date_default_timezone_get();
+        date_default_timezone_set('America/Vancouver');
+
+        parent::setUp();
+    }
+
+    protected function tearDown()
+    {
+        date_default_timezone_set($this->tz);
+
+        if (function_exists('zend_disk_cache_clear')) {
+            zend_disk_cache_clear();
+        }
+
+        parent::tearDown();
+    }
+
+    public function createCachePool()
+    {
+        $storage = StorageFactory::factory([
+            'adapter' => [
+                'name'    => 'xcache',
+                'options' => [],
+            ],
+        ]);
+        return new CacheItemPoolAdapter($storage);
+    }
+}

--- a/test/Psr/ZendServerDiskIntegrationTest.php
+++ b/test/Psr/ZendServerDiskIntegrationTest.php
@@ -6,6 +6,7 @@
  * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
+
 namespace ZendTest\Cache\Psr;
 
 use Cache\IntegrationTests\CachePoolTest;

--- a/test/Psr/ZendServerShmIntegrationTest.php
+++ b/test/Psr/ZendServerShmIntegrationTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/).
+ *
+ * @link      http://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+namespace ZendTest\Cache\Psr;
+
+use Cache\IntegrationTests\CachePoolTest;
+use Zend\Cache\Psr\CacheItemPoolAdapter;
+use Zend\Cache\StorageFactory;
+
+class ZendServerShmIntegrationTest extends CachePoolTest
+{
+    private $tz;
+
+    protected function setUp()
+    {
+        if (!getenv('TESTS_ZEND_CACHE_ZEND_SERVER_ENABLED')) {
+            $this->markTestSkipped('Enable TESTS_ZEND_CACHE_ZEND_SERVER_ENABLED to run this test');
+        }
+
+        if (!function_exists('zend_shm_cache_store') || PHP_SAPI == 'cli') {
+            $this->markTestSkipped("Missing 'zend_shm_cache_*' functions or running from SAPI 'cli'");
+        }
+
+        // set non-UTC timezone
+        $this->tz = date_default_timezone_get();
+        date_default_timezone_set('America/Vancouver');
+
+        parent::setUp();
+    }
+
+    protected function tearDown()
+    {
+        date_default_timezone_set($this->tz);
+
+        if (function_exists('zend_shm_cache_clear')) {
+            zend_disk_cache_clear();
+        }
+
+        parent::tearDown();
+    }
+
+    public function createCachePool()
+    {
+        $storage = StorageFactory::factory([
+            'adapter' => [
+                'name'    => 'xcache',
+                'options' => [],
+            ],
+        ]);
+        return new CacheItemPoolAdapter($storage);
+    }
+}

--- a/test/Psr/ZendServerShmIntegrationTest.php
+++ b/test/Psr/ZendServerShmIntegrationTest.php
@@ -6,6 +6,7 @@
  * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
+
 namespace ZendTest\Cache\Psr;
 
 use Cache\IntegrationTests\CachePoolTest;


### PR DESCRIPTION
This PR address #46, adding a [PSR-6](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-6-cache.md) wrapper.

Some key points:

* Not all storage adapters are supported, due the PSR-6 requirement that individual cache items must support separate TTLs, set on save. This rules out Dba, Filesystem, Memory, Session and Redis < v2
* PSR-6 [Error Handling](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-6-cache.md#error-handling) requires that most exceptions thrown by the storage adapter be suppressed. I've provided an `ExceptionLogger` so these can be saved to a PSR-3 compatible logger. Some documentation is probably in order!
* There are some useful integration tests at https://github.com/php-cache/integration-tests. I haven't got around to incorporating those yet - only discovered them yesterday.

Happy New Year!