### PR TITLE
Fix for #58

### DIFF
--- a/src/Storage/Adapter/XCache.php
+++ b/src/Storage/Adapter/XCache.php
@@ -54,9 +54,9 @@ class XCache extends AbstractAdapter implements
             throw new Exception\ExtensionNotLoadedException('Missing ext/xcache');
         }
 
-        if (PHP_SAPI == 'cli') {
+        if (PHP_SAPI == 'cli' && version_compare(phpversion('xcache'), '3.1.0') < 0) {
             throw new Exception\ExtensionNotLoadedException(
-                "ext/xcache isn't available on SAPI 'cli'"
+                "ext/xcache isn't available on SAPI 'cli' for versions less than 3.1.0"
             );
         }
 
@@ -341,9 +341,16 @@ class XCache extends AbstractAdapter implements
     {
         $options     = $this->getOptions();
         $namespace   = $options->getNamespace();
-        $prefix      = ($options === '') ? '' : $namespace . $options->getNamespaceSeparator();
+        $prefix      = ($namespace === '') ? '' : $namespace . $options->getNamespaceSeparator();
         $internalKey = $prefix . $normalizedKey;
         $ttl         = $options->getTtl();
+
+        if (is_object($value) || is_resource($value) || is_callable($value)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                "Cannot store data of type %s",
+                gettype($value)
+            ));
+        }
 
         if (!xcache_set($internalKey, $value, $ttl)) {
             $type = is_object($value) ? get_class($value) : gettype($value);
@@ -434,7 +441,7 @@ class XCache extends AbstractAdapter implements
                         'double'   => true,
                         'string'   => true,
                         'array'    => true,
-                        'object'   => 'object',
+                        'object'   => false,
                         'resource' => false,
                     ],
                     'supportedMetadata' => [

--- a/src/Storage/Adapter/XCache.php
+++ b/src/Storage/Adapter/XCache.php
@@ -345,7 +345,7 @@ class XCache extends AbstractAdapter implements
         $internalKey = $prefix . $normalizedKey;
         $ttl         = $options->getTtl();
 
-        if (is_object($value) || is_resource($value) || is_callable($value)) {
+        if (is_object($value) || is_resource($value)) {
             throw new Exception\InvalidArgumentException(sprintf(
                 "Cannot store data of type %s",
                 gettype($value)

--- a/test/Storage/Adapter/XCacheTest.php
+++ b/test/Storage/Adapter/XCacheTest.php
@@ -34,7 +34,7 @@ class XCacheTest extends CommonAdapterTest
             }
         }
 
-        if (PHP_SAPI == 'cli') {
+        if (PHP_SAPI == 'cli' && version_compare(phpversion('xcache'), '3.1.0') < 0) {
             try {
                 new Cache\Storage\Adapter\XCache();
                 $this->fail("Expected exception Zend\Cache\Exception\ExtensionNotLoadedException");


### PR DESCRIPTION
* XCache adapter now checks version > 3.1.0 when running under CLI
* fixed broken internalSetItem() with empty namespace

Don't got the chops to get travis building the xcache extension so the tests can run - doesn't look like it's avail from pecl (I get mine from brew). Anyone got any ideas?