### PR TITLE
Use v2-compatible EventManager instantiation when lazy-loading

### DIFF
--- a/src/Storage/Adapter/AbstractAdapter.php
+++ b/src/Storage/Adapter/AbstractAdapter.php
@@ -23,7 +23,6 @@ use Zend\Cache\Storage\StorageInterface;
 use Zend\EventManager\EventManager;
 use Zend\EventManager\EventManagerInterface;
 use Zend\EventManager\EventsCapableInterface;
-use Zend\EventManager\SharedEventManager;
 
 abstract class AbstractAdapter implements StorageInterface, EventsCapableInterface
 {
@@ -190,7 +189,8 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
     public function getEventManager()
     {
         if ($this->events === null) {
-            $this->events = new EventManager(new SharedEventManager(), [__CLASS__, get_class($this)]);
+            $this->events = new EventManager();
+            $this->events->setIdentifiers([__CLASS__, get_class($this)]);
         }
         return $this->events;
     }

--- a/test/Storage/Adapter/EventManagerCompatibilityTest.php
+++ b/test/Storage/Adapter/EventManagerCompatibilityTest.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   Zend_Cache
+ */
+
+namespace ZendTest\Cache\Storage\Adapter;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Zend\Cache\Storage\Adapter\AbstractAdapter;
+use Zend\EventManager\EventManager;
+use ZendTest\Cache\Storage\TestAsset\MockAdapter;
+
+class EventManagerCompatibilityTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->adapter = new MockAdapter();
+    }
+
+    public function testCanLazyLoadEventManager()
+    {
+        $events = $this->adapter->getEventManager();
+        $this->assertInstanceOf(EventManager::class, $events);
+        return $events;
+    }
+
+    /**
+     * @depends testCanLazyLoadEventManager
+     */
+    public function testLazyLoadedEventManagerIsInjectedProperlyWithDefaultIdentifiers(EventManager $events)
+    {
+        $this->assertEquals([
+            AbstractAdapter::class,
+            MockAdapter::class,
+        ], $events->getIdentifiers());
+    }
+}


### PR DESCRIPTION
Per #71, `getEventManager()`, when lazy-loading an `EventManager`, was using the v3 syntax, instead of v2-compatible syntax, causing identifiers to break under v2 (as they are now injected with a `SharedEventManager` instance instead).

This patch:

- Adds a compatiblity test to ensure that the usage works on both v2 and v3.
- Fixes the lazy-loading code to instantiate and then inject identifiers.

This also addresses #72, as the problem presented in that report is due to the fact that the `SharedEventManager` was injected as an identifier, and identifiers are only allowed to be strings or integers.