### PR TITLE
ZendServer: fixed return null on missing item

### DIFF
--- a/src/Storage/Adapter/AbstractZendServer.php
+++ b/src/Storage/Adapter/AbstractZendServer.php
@@ -39,7 +39,8 @@ abstract class AbstractZendServer extends AbstractAdapter
         $prefix      = ($namespace === '') ? '' : $namespace . self::NAMESPACE_SEPARATOR;
 
         $result = $this->zdcFetch($prefix . $normalizedKey);
-        if ($result === null) {
+        if ($result === false) {
+            $result  = null;
             $success = false;
         } else {
             $success  = true;

--- a/src/Storage/Adapter/ZendServerDisk.php
+++ b/src/Storage/Adapter/ZendServerDisk.php
@@ -148,7 +148,7 @@ class ZendServerDisk extends AbstractZendServer implements
      * Fetch a single item from Zend Data Disk Cache
      *
      * @param  string $internalKey
-     * @return mixed The stored value or NULL if item wasn't found
+     * @return mixed The stored value or FALSE if item wasn't found
      * @throws Exception\RuntimeException
      */
     protected function zdcFetch($internalKey)

--- a/src/Storage/Adapter/ZendServerShm.php
+++ b/src/Storage/Adapter/ZendServerShm.php
@@ -103,7 +103,7 @@ class ZendServerShm extends AbstractZendServer implements
      * Fetch a single item from Zend Data SHM Cache
      *
      * @param  string $internalKey
-     * @return mixed The stored value or NULL if item wasn't found
+     * @return mixed The stored value or FALSE if item wasn't found
      * @throws Exception\RuntimeException
      */
     protected function zdcFetch($internalKey)

--- a/test/Storage/Adapter/AbstractZendServerTest.php
+++ b/test/Storage/Adapter/AbstractZendServerTest.php
@@ -59,7 +59,7 @@ class AbstractZendServerTest extends \PHPUnit_Framework_TestCase
         $this->_storage->expects($this->once())
                        ->method('zdcFetch')
                        ->with($this->equalTo('ns' . AbstractZendServer::NAMESPACE_SEPARATOR . 'key'))
-                       ->will($this->returnValue(null));
+                       ->will($this->returnValue(false));
 
         $this->assertNull($this->_storage->getItem('key', $success));
         $this->assertFalse($success);


### PR DESCRIPTION
This bug was introduced by zendframework/zf2#5597 (v2.2.6)

@weierophinney You merged the old issue and you probably know more about the Zend products.

I installed the last Zend Server (v8.5.0 trial) and run the tests but it failed.
The reason is that `zend_[shm|disk]_cache_fetch` behaves exactly the opposite as described in zendframework/zf2#5597.

Also they are pointing to http://files.zend.com/help/Zend-Platform/zend_cache_functions.htm in the old issue but this adapter is for Zend Server and not for Zend Platform.
-> see http://files.zend.com/help/Zend-Server/content/zendserverapi/zend_data_cache-php_api.htm#function-zend_shm_cache_fetch

@neeckeloo  @anvi ping