### PR TITLE
Bugfix/clear by tag on filesystem storage while files are already deleted

### DIFF
--- a/src/Storage/Adapter/Filesystem.php
+++ b/src/Storage/Adapter/Filesystem.php
@@ -331,15 +331,11 @@ class Filesystem extends AbstractAdapter implements
             try {
                 $diff = array_diff($tags, explode("\n", $this->getFileContent($pathname)));
             } catch (Exception\RuntimeException $exception) {
-                if ($exception->getPrevious()
-                    && strpos(
-                        $exception->getPrevious()->getMessage(),
-                        'failed to open stream: No such file or directory'
-                    ) !== false
-                ) {
+                // ignore missing files because of possible raise conditions
+                // e.g. another process already deleted that item
+                if (!file_exists($pathname)) {
                     continue;
                 }
-
                 throw $exception;
             }
 

--- a/src/Storage/Adapter/Filesystem.php
+++ b/src/Storage/Adapter/Filesystem.php
@@ -328,7 +328,20 @@ class Filesystem extends AbstractAdapter implements
         $glob = new GlobIterator($path, $flags);
 
         foreach ($glob as $pathname) {
-            $diff = array_diff($tags, explode("\n", $this->getFileContent($pathname)));
+            try {
+                $diff = array_diff($tags, explode("\n", $this->getFileContent($pathname)));
+            } catch (Exception\RuntimeException $exception) {
+                if ($exception->getPrevious()
+                    && strpos(
+                        $exception->getPrevious()->getMessage(),
+                        'failed to open stream: No such file or directory'
+                    ) !== false
+                ) {
+                    continue;
+                }
+
+                throw $exception;
+            }
 
             $rem  = false;
             if ($disjunction && count($diff) < $tagCount) {

--- a/test/Storage/Adapter/FilesystemDelayedUnlink.php
+++ b/test/Storage/Adapter/FilesystemDelayedUnlink.php
@@ -2,7 +2,8 @@
 
 namespace Zend\Cache\Storage\Adapter;
 
-function unlink($path, $context = null) {
+function unlink($path, $context = null)
+{
     usleep(150000);
     if ($context) {
         return \unlink($path, $context);

--- a/test/Storage/Adapter/FilesystemDelayedUnlink.php
+++ b/test/Storage/Adapter/FilesystemDelayedUnlink.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Zend\Cache\Storage\Adapter;
+
+function unlink($path, $context = null) {
+    usleep(150000);
+    if ($context) {
+        return \unlink($path, $context);
+    }
+
+    return \unlink($path);
+}

--- a/test/Storage/Adapter/FilesystemTest.php
+++ b/test/Storage/Adapter/FilesystemTest.php
@@ -334,6 +334,10 @@ class FilesystemTest extends CommonAdapterTest
      */
     public function testClearByTagsWithoutLocking()
     {
+        if (!function_exists('pcntl_fork') || !function_exists('posix_kill')) {
+            $this->markTestSkipped('Missing pcntl_fork and/or posix_kill');
+        }
+
         // create cache items
         $this->_storage->getOptions()->setDirLevel(0);
         $this->_storage->getOptions()->setFileLocking(false);
@@ -378,6 +382,10 @@ class FilesystemTest extends CommonAdapterTest
      */
     public function testClearByTagsWithLocking()
     {
+        if (!function_exists('pcntl_fork') || !function_exists('posix_kill')) {
+            $this->markTestSkipped('Missing pcntl_fork and/or posix_kill');
+        }
+
         // create cache items
         $this->_storage->getOptions()->setDirLevel(0);
         $this->_storage->getOptions()->setFileLocking(true);

--- a/test/Storage/Adapter/FilesystemTest.php
+++ b/test/Storage/Adapter/FilesystemTest.php
@@ -347,15 +347,9 @@ class FilesystemTest extends CommonAdapterTest
         $this->_storage->setTags('b_key', ['a_tag', 'b_tag']);
         $this->_storage->setItem('c_key', 'c_value');
         $this->_storage->setTags('c_key', ['a_tag', 'c_tag']);
-        //$this->_storage->getTags('a_key');
 
-        //unlink($this->_tmpCacheDir.'/zfcache-a_key.tag');
-
-        //var_dump($this->_storage->getTags('a_key'));
-
-        // tempFile used for communication between parent and child.
         $tempFile = tmpfile();
-        // Split into two..
+        
         $pid = pcntl_fork();
         if ($pid == -1) {
             $this->fail('pcntl_fork() failed');

--- a/test/Storage/Adapter/FilesystemTest.php
+++ b/test/Storage/Adapter/FilesystemTest.php
@@ -411,4 +411,3 @@ class FilesystemTest extends CommonAdapterTest
         }
     }
 }
-

--- a/test/Storage/Adapter/FilesystemTest.php
+++ b/test/Storage/Adapter/FilesystemTest.php
@@ -330,7 +330,6 @@ class FilesystemTest extends CommonAdapterTest
     }
 
     /**
-     * @group d
      * @runInSeparateProcess
      */
     public function testClearByTagsWithoutLocking()

--- a/test/Storage/Adapter/FilesystemTest.php
+++ b/test/Storage/Adapter/FilesystemTest.php
@@ -349,7 +349,7 @@ class FilesystemTest extends CommonAdapterTest
         $this->_storage->setTags('c_key', ['a_tag', 'c_tag']);
 
         $tempFile = tmpfile();
-        
+
         $pid = pcntl_fork();
         if ($pid == -1) {
             $this->fail('pcntl_fork() failed');

--- a/test/Storage/Adapter/FilesystemTest.php
+++ b/test/Storage/Adapter/FilesystemTest.php
@@ -371,7 +371,7 @@ class FilesystemTest extends CommonAdapterTest
             fclose($tempFile);
         } else {
             usleep(150000);
-            unlink($this->_tmpCacheDir.'/zfcache-c_key.tag');
+            $this->_storage->removeItem('c_key');
             fwrite($tempFile, 'deleted');
             posix_kill(posix_getpid(), SIGTERM);
         }
@@ -413,7 +413,7 @@ class FilesystemTest extends CommonAdapterTest
             fclose($tempFile);
         } else {
             usleep(150000);
-            unlink($this->_tmpCacheDir.'/zfcache-c_key.tag');
+            $this->_storage->removeItem('c_key');
             fwrite($tempFile, 'deleted');
             posix_kill(posix_getpid(), SIGTERM);
         }

--- a/test/Storage/Adapter/FilesystemTest.php
+++ b/test/Storage/Adapter/FilesystemTest.php
@@ -330,6 +330,7 @@ class FilesystemTest extends CommonAdapterTest
     }
 
     /**
+     * @group d
      * @runInSeparateProcess
      */
     public function testClearByTagsWithoutLocking()
@@ -354,7 +355,7 @@ class FilesystemTest extends CommonAdapterTest
         // Split into two..
         $pid = pcntl_fork();
         if ($pid == -1) {
-            $this->assertEquals('shit went down. [failed to fork]', 'no shit went down');
+            $this->fail('pcntl_fork() failed');
         }
         if ($pid) {
             require 'FilesystemDelayedUnlink.php';
@@ -392,7 +393,7 @@ class FilesystemTest extends CommonAdapterTest
 
         $pid = pcntl_fork();
         if ($pid == -1) {
-            $this->assertEquals('shit went down. [failed to fork]', 'no shit went down');
+            $this->fail('pcntl_fork() failed');
         }
         if ($pid) {
             require 'FilesystemDelayedUnlink.php';


### PR DESCRIPTION
This PR fixes the behavior on the special case that file content is read while tag file is deleted

More description in #44 

@marc-mabe is this kind of try...catch solution you had in mind?

Merging this PR closes #44 