### PR TITLE
Adds Redis sIsMember and sAdd Taggable capabilities [POC]

### DIFF
--- a/src/Storage/Adapter/AbstractAdapter.php
+++ b/src/Storage/Adapter/AbstractAdapter.php
@@ -321,53 +321,6 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
     /* reading */
 
     /**
-     * Returns if value is a member of the set stored at key.
-     *
-     * @param  string  $key
-     * @param  string  $value
-     * @return int 1 if the element is a member of the set, 0 if not or key doesn't exist
-     * @throws Exception\ExceptionInterface
-     *
-     * @triggers sIsMember.pre(PreEvent)
-     * @triggers sIsMember.post(PostEvent)
-     * @triggers sIsMember.exception(ExceptionEvent)
-     */
-    public function sIsMember($key, $value)
-    {
-        if (!$this->getOptions()->getReadable()) {
-            return false;
-        }
-
-        $this->normalizeKey($key);
-        $args = new ArrayObject([
-            'key'   => & $key,
-            'value' => & $value
-        ]);
-
-        try {
-            $eventRs = $this->triggerPre(__FUNCTION__, $args);
-
-            $result = $eventRs->stopped()
-                ? $eventRs->last()
-                : $this->internalSIsMember($args['key'], $args['value']);
-
-            return $this->triggerPost(__FUNCTION__, $args, $result);
-        } catch (\Exception $e) {
-            $result = 0;
-            return $this->triggerException(__FUNCTION__, $args, $result, $e);
-        }
-    }
-
-    /**
-     * Internal method to check if value is a member of the set stored at key.
-     *
-     * @param  string $normalizedKey
-     * @param $value
-     * @return int 1 if the element is a member of the set, 0 if not or key doesn't exist
-     */
-    abstract protected function internalSIsMember(& $normalizedKey, & $value);
-
-    /**
      * Get an item.
      *
      * @param  string  $key
@@ -702,58 +655,6 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
     }
 
     /* writing */
-
-    /**
-     * Add the specified values to the set stored at key
-     *
-     * Specified members that are already a member of this set are ignored.
-     * If key does not exist, a new set is created before adding the specified members.
-     *
-     * @param $key
-     * @param $value
-     * @return int number of elements that were added to the set
-     * @throws Exception\ExceptionInterface
-     *
-     * @triggers sAdd.pre(PreEvent)
-     * @triggers sAdd.post(PostEvent)
-     * @triggers sAdd.exception(ExceptionEvent)
-     *
-     */
-    public function sAdd($key, $value)
-    {
-        if (!$this->getOptions()->getWritable()) {
-            return false;
-        }
-
-        $this->normalizeKey($key);
-        $args = new ArrayObject([
-            'key'   => & $key,
-            'value' => & $value,
-        ]);
-
-        try {
-            $eventRs = $this->triggerPre(__FUNCTION__, $args);
-
-            $result = $eventRs->stopped()
-                ? $eventRs->last()
-                : $this->internalSAdd($args['key'], $args['value']);
-
-            return $this->triggerPost(__FUNCTION__, $args, $result);
-        } catch (\Exception $e) {
-            $result = false;
-            return $this->triggerException(__FUNCTION__, $args, $result, $e);
-        }
-    }
-
-    /**
-     * Internal method to add the specified values to the set stored at key.
-     *
-     * @param  string $normalizedKey
-     * @param  mixed  $value
-     * @return bool
-     * @throws Exception\ExceptionInterface
-     */
-    abstract protected function internalSAdd(& $normalizedKey, & $value);
 
     /**
      * Store an item.

--- a/src/Storage/Adapter/AbstractAdapter.php
+++ b/src/Storage/Adapter/AbstractAdapter.php
@@ -321,6 +321,53 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
     /* reading */
 
     /**
+     * Returns if value is a member of the set stored at key.
+     *
+     * @param  string  $key
+     * @param  string  $value
+     * @return int 1 if the element is a member of the set, 0 if not or key doesn't exist
+     * @throws Exception\ExceptionInterface
+     *
+     * @triggers sIsMember.pre(PreEvent)
+     * @triggers sIsMember.post(PostEvent)
+     * @triggers sIsMember.exception(ExceptionEvent)
+     */
+    public function sIsMember($key, $value)
+    {
+        if (!$this->getOptions()->getReadable()) {
+            return false;
+        }
+
+        $this->normalizeKey($key);
+        $args = new ArrayObject([
+            'key'   => & $key,
+            'value' => & $value
+        ]);
+
+        try {
+            $eventRs = $this->triggerPre(__FUNCTION__, $args);
+
+            $result = $eventRs->stopped()
+                ? $eventRs->last()
+                : $this->internalSIsMember($args['key'], $args['value']);
+
+            return $this->triggerPost(__FUNCTION__, $args, $result);
+        } catch (\Exception $e) {
+            $result = 0;
+            return $this->triggerException(__FUNCTION__, $args, $result, $e);
+        }
+    }
+
+    /**
+     * Internal method to check if value is a member of the set stored at key.
+     *
+     * @param  string $normalizedKey
+     * @param $value
+     * @return int 1 if the element is a member of the set, 0 if not or key doesn't exist
+     */
+    abstract protected function internalSIsMember(& $normalizedKey, & $value);
+
+    /**
      * Get an item.
      *
      * @param  string  $key
@@ -655,6 +702,58 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
     }
 
     /* writing */
+
+    /**
+     * Add the specified values to the set stored at key
+     *
+     * Specified members that are already a member of this set are ignored.
+     * If key does not exist, a new set is created before adding the specified members.
+     *
+     * @param $key
+     * @param $value
+     * @return int number of elements that were added to the set
+     * @throws Exception\ExceptionInterface
+     *
+     * @triggers sAdd.pre(PreEvent)
+     * @triggers sAdd.post(PostEvent)
+     * @triggers sAdd.exception(ExceptionEvent)
+     *
+     */
+    public function sAdd($key, $value)
+    {
+        if (!$this->getOptions()->getWritable()) {
+            return false;
+        }
+
+        $this->normalizeKey($key);
+        $args = new ArrayObject([
+            'key'   => & $key,
+            'value' => & $value,
+        ]);
+
+        try {
+            $eventRs = $this->triggerPre(__FUNCTION__, $args);
+
+            $result = $eventRs->stopped()
+                ? $eventRs->last()
+                : $this->internalSAdd($args['key'], $args['value']);
+
+            return $this->triggerPost(__FUNCTION__, $args, $result);
+        } catch (\Exception $e) {
+            $result = false;
+            return $this->triggerException(__FUNCTION__, $args, $result, $e);
+        }
+    }
+
+    /**
+     * Internal method to add the specified values to the set stored at key.
+     *
+     * @param  string $normalizedKey
+     * @param  mixed  $value
+     * @return bool
+     * @throws Exception\ExceptionInterface
+     */
+    abstract protected function internalSAdd(& $normalizedKey, & $value);
 
     /**
      * Store an item.

--- a/src/Storage/Adapter/Redis.php
+++ b/src/Storage/Adapter/Redis.php
@@ -430,21 +430,22 @@ class Redis extends AbstractAdapter implements
             return false;
         }
 
-        $redis     = $this->getRedisResource();
-        $it        = null;
+        $redis = $this->getRedisResource();
+        $it    = null;
         try {
             $arrKeys = $redis->scan($it);
-            foreach($arrKeys as $key) {
+            foreach ($arrKeys as $key) {
                 $redisKey = $redis->sMembers($key);
-                if (!$disjunction) {
+                if (! $disjunction) {
                     if (is_array($redisKey) && empty(array_diff($tags,  $redisKey))) {
-                        foreach ($tags as $tag) {
-                            $redis->sRem($key, $tag);
-                        }
+                        $redis->delete($key);
                     }
                 } else {
                     foreach ($tags as $tag) {
-                        $redis->sRem($key, $tag);
+                        if ($redis->sIsMember($key, $tag)) {
+                            $redis->delete($key);
+                            continue;
+                        }
                     }
                 }
             }

--- a/src/Storage/Adapter/Redis.php
+++ b/src/Storage/Adapter/Redis.php
@@ -457,6 +457,30 @@ class Redis extends AbstractAdapter implements
     }
 
     /**
+     * Unlike clearByTags this removes a single or more tags from a set
+     * keeping the existing item tags intact
+     *
+     * @param $key
+     * @param array $tags
+     * @return bool
+     * @throws Exception\RuntimeException
+     */
+    public function removeTags($key, array $tags)
+    {
+        $this->normalizeKey($key);
+        $redis = $this->getRedisResource();
+        try {
+            foreach ($tags as $tag) {
+                $redis->sRem($this->namespacePrefix . $key, $tag);
+            }
+        } catch (RedisResourceException $e) {
+            throw new Exception\RuntimeException($redis->getLastError(), $e->getCode(), $e);
+        }
+
+        return true;
+    }
+
+    /**
      * Internal method to remove an item.
      *
      * @param string &$normalizedKey Key which will be removed

--- a/src/Storage/Adapter/Redis.php
+++ b/src/Storage/Adapter/Redis.php
@@ -206,8 +206,7 @@ class Redis extends AbstractAdapter implements
     {
         $redis = $this->getRedisResource();
         try {
-            $value = $redis->sIsMember($this->namespacePrefix . $normalizedKey, $value);
-            return $value;
+            return $redis->sIsMember($this->namespacePrefix . $normalizedKey, $value);
         } catch (RedisResourceException $e) {
             throw new Exception\RuntimeException($redis->getLastError(), $e->getCode(), $e);
         }

--- a/src/Storage/Adapter/Redis.php
+++ b/src/Storage/Adapter/Redis.php
@@ -423,7 +423,7 @@ class Redis extends AbstractAdapter implements
                 $key2 !== null ? $this->namespacePrefix . $key2 : null,
                 $key3 !== null ? $this->namespacePrefix . $key3 : null
             );
-        } catch(RedisResourceException $e) {
+        } catch (RedisResourceException $e) {
             throw new Exception\RuntimeException($redis->getLastError(), $e->getCode(), $e);
         }
     }
@@ -447,7 +447,8 @@ class Redis extends AbstractAdapter implements
         $key      = key($tags);
         $redis    = $this->getRedisResource();
         $remCount = 0;
-        foreach ($tags as $tag) {
+
+        foreach ($tags[$key] as $tag) {
             try {
                 $remCount += $redis->sRem($this->namespacePrefix . $key, $tag);
             } catch (RedisResourceException $e) {

--- a/src/Storage/Adapter/Redis.php
+++ b/src/Storage/Adapter/Redis.php
@@ -195,6 +195,25 @@ class Redis extends AbstractAdapter implements
     }
 
     /**
+     * Add the specified values to the set stored at key.
+     *
+     * @param  string $normalizedKey
+     * @param  mixed  $value
+     * @return bool
+     * @throws Exception\RuntimeException
+     */
+    protected function internalSIsMember(& $normalizedKey, & $value)
+    {
+        $redis = $this->getRedisResource();
+        try {
+            $value = $redis->sIsMember($this->namespacePrefix . $normalizedKey, $value);
+            return $value;
+        } catch (RedisResourceException $e) {
+            throw new Exception\RuntimeException($redis->getLastError(), $e->getCode(), $e);
+        }
+    }
+
+    /**
      * Internal method to test if an item exists.
      *
      * @param string &$normalizedKey Normalized key which will be checked
@@ -284,6 +303,24 @@ class Redis extends AbstractAdapter implements
         }
 
         return [];
+    }
+
+    /**
+     * Add the specified values to the set stored at key.
+     *
+     * @param  string $normalizedKey
+     * @param  mixed  $value
+     * @return bool
+     * @throws Exception\RuntimeException
+     */
+    protected function internalSAdd(& $normalizedKey, & $value)
+    {
+        $redis = $this->getRedisResource();
+        try {
+            return $redis->sAdd($this->namespacePrefix . $normalizedKey, $value);
+        } catch (RedisResourceException $e) {
+            throw new Exception\RuntimeException($redis->getLastError(), $e->getCode(), $e);
+        }
     }
 
     /**


### PR DESCRIPTION
#### PROOF OF CONCEPT

- Implementation could also just be added to redis alone, as apposed to the Abstract Adapter ?

fixes #83

example request:

```php
$this->redis->sAdd('key', 'value1');
$this->redis->sAdd('key', 'value2');
$this->redis->sAdd('key', 'value3');

$this->sIsMember('key', 'value1'); // returns true
$this->sIsMember('key', 'value2'); // returns true
$this->sIsMember('key', 'value6'); // returns false
```