### PR TITLE
Allow testing against session adapter with v3 components

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,6 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
   - if [[ $SERVICE_MANAGER_VERSION != '' ]]; then composer require --no-update "zendframework/zend-servicemanager:$SERVICE_MANAGER_VERSION" ; fi
   - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer require --no-update "zendframework/zend-servicemanager:^3.0.3" ; fi
-  - if [[ $SERVICE_MANAGER_VERSION == '' ]]; then composer remove --dev --no-update zendframework/zend-session ; fi
   - if [[ $EVENT_MANAGER_VERSION != '' ]]; then composer require --no-update "zendframework/zend-eventmanager:$EVENT_MANAGER_VERSION" ; fi
   - if [[ $EVENT_MANAGER_VERSION == '' ]]; then composer require --no-update "zendframework/zend-eventmanager:^3.0" ; fi
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "zendframework/zend-serializer": "^2.6",
-        "zendframework/zend-session": "^2.5",
+        "zendframework/zend-session": "^2.6.2",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"
     },

--- a/test/Storage/Adapter/SessionTest.php
+++ b/test/Storage/Adapter/SessionTest.php
@@ -20,14 +20,6 @@ class SessionTest extends CommonAdapterTest
 {
     public function setUp()
     {
-        if (! class_exists(SessionContainer::class)) {
-            $this->markTestSkipped(
-                'Skipping zend-session-related tests until that component is '
-                . 'forwards-compatible with zend-stdlib, zend-servicemanager, '
-                . 'and zend-eventmanager v3'
-            );
-        }
-
         $_SESSION = [];
         SessionContainer::setDefaultManager(null);
         $sessionContainer = new SessionContainer('Default');


### PR DESCRIPTION
Now that zend-session has been updated to work with the v3 components, we can enable its tests when on Travis.