### PR TITLE
filesystem: fixes a lot of possible race conditions

### DIFF
--- a/test/Storage/Adapter/FilesystemTest.php
+++ b/test/Storage/Adapter/FilesystemTest.php
@@ -338,15 +338,18 @@ class FilesystemTest extends CommonAdapterTest
     /**
      * @runInSeparateProcess
      */
-    public function testClearByTagsWithoutLocking()
+    public function testRaceConditionInClearByTags()
     {
         if (!function_exists('pcntl_fork') || !function_exists('posix_kill')) {
             $this->markTestSkipped('Missing pcntl_fork and/or posix_kill');
         }
 
+        // delay unlink() by global variable $unlinkDelay
+        global $unlinkDelay;
+        require __DIR__ . '/TestAsset/FilesystemDelayedUnlink.php';
+
         // create cache items
         $this->_storage->getOptions()->setDirLevel(0);
-        $this->_storage->getOptions()->setFileLocking(false);
         $this->_storage->setItems([
             'a_key' => 'a_value',
             'b_key' => 'b_value',
@@ -362,14 +365,15 @@ class FilesystemTest extends CommonAdapterTest
             // The parent process
             // Slow down unlink function and start removing items.
             // Finally test if the item not matching the tag was removed by the child process.
-            require __DIR__ . '/TestAsset/FilesystemDelayedUnlink.php';
+            $unlinkDelay = 5000;
+
             $this->_storage->clearByTags(['a_tag'], true);
-            $this->assertFalse($this->_storage->hasItem('other'));
+            $this->assertFalse($this->_storage->hasItem('other'), 'Child process does not run as expected');
         } else {
             // The child process:
             // Wait to make sure the parent process has started determining files to unlink.
             // Than remove one of the items the parent process should remove and another item for testing.
-            usleep(10000);
+            usleep(1000);
             $this->_storage->removeItems(['b_key', 'other']);
             posix_kill(posix_getpid(), SIGTERM);
         }
@@ -378,22 +382,27 @@ class FilesystemTest extends CommonAdapterTest
     /**
      * @runInSeparateProcess
      */
-    public function testClearByTagsWithLocking()
+    public function testRaceConditionInClearByNamespace()
     {
         if (!function_exists('pcntl_fork') || !function_exists('posix_kill')) {
             $this->markTestSkipped('Missing pcntl_fork and/or posix_kill');
         }
 
+        // delay unlink() by global variable $unlinkDelay
+        global $unlinkDelay;
+        require __DIR__ . '/TestAsset/FilesystemDelayedUnlink.php';
+
         // create cache items
         $this->_storage->getOptions()->setDirLevel(0);
-        $this->_storage->getOptions()->setFileLocking(true);
+        $this->_storage->getOptions()->setNamespace('ns-other');
+        $this->_storage->setItems([
+            'other' => 'other',
+        ]);
+        $this->_storage->getOptions()->setNamespace('ns-4-clear');
         $this->_storage->setItems([
             'a_key' => 'a_value',
             'b_key' => 'b_value',
-            'other' => 'other',
         ]);
-        $this->_storage->setTags('a_key', ['a_tag']);
-        $this->_storage->setTags('b_key', ['a_tag']);
 
         $pidChild = pcntl_fork();
         if ($pidChild == -1) {
@@ -402,15 +411,178 @@ class FilesystemTest extends CommonAdapterTest
             // The parent process
             // Slow down unlink function and start removing items.
             // Finally test if the item not matching the tag was removed by the child process.
-            require __DIR__ . '/TestAsset/FilesystemDelayedUnlink.php';
-            $this->_storage->clearByTags(['a_tag'], true);
-            $this->assertFalse($this->_storage->hasItem('other'));
+            $unlinkDelay = 5000;
+
+            $this->_storage->getOptions()->setNamespace('ns-4-clear');
+            $this->_storage->clearByNamespace('ns-4-clear');
+
+            $this->assertFalse($this->_storage->hasItem('a_key'));
+            $this->assertFalse($this->_storage->hasItem('b_key'));
+
+            $this->_storage->getOptions()->setNamespace('ns-other');
+            $this->assertFalse($this->_storage->hasItem('other'), 'Child process does not run as expected');
         } else {
             // The child process:
             // Wait to make sure the parent process has started determining files to unlink.
             // Than remove one of the items the parent process should remove and another item for testing.
-            usleep(10000);
-            $this->_storage->removeItems(['b_key', 'other']);
+            usleep(1000);
+
+            $this->_storage->getOptions()->setNamespace('ns-4-clear');
+            $this->assertTrue($this->_storage->removeItem('b_key'));
+
+            $this->_storage->getOptions()->setNamespace('ns-other');
+            $this->assertTrue($this->_storage->removeItem('other'));
+
+            posix_kill(posix_getpid(), SIGTERM);
+        }
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testRaceConditionInClearByPrefix()
+    {
+        if (!function_exists('pcntl_fork') || !function_exists('posix_kill')) {
+            $this->markTestSkipped('Missing pcntl_fork and/or posix_kill');
+        }
+
+        // delay unlink() by global variable $unlinkDelay
+        global $unlinkDelay;
+        require __DIR__ . '/TestAsset/FilesystemDelayedUnlink.php';
+
+        // create cache items
+        $this->_storage->getOptions()->setDirLevel(0);
+        $this->_storage->getOptions()->setNamespace('ns');
+        $this->_storage->setItems([
+            'prefix_a_key' => 'a_value',
+            'prefix_b_key' => 'b_value',
+            'other'        => 'other',
+        ]);
+
+        $pidChild = pcntl_fork();
+        if ($pidChild == -1) {
+            $this->fail('pcntl_fork() failed');
+        } elseif ($pidChild) {
+            // The parent process
+            // Slow down unlink function and start removing items.
+            // Finally test if the item not matching the tag was removed by the child process.
+            $unlinkDelay = 5000;
+
+            $this->_storage->clearByPrefix('prefix_');
+
+            $this->assertFalse($this->_storage->hasItem('prefix_a_key'));
+            $this->assertFalse($this->_storage->hasItem('prefix_b_key'));
+
+            $this->assertFalse($this->_storage->hasItem('other'), 'Child process does not run as expected');
+        } else {
+            // The child process:
+            // Wait to make sure the parent process has started determining files to unlink.
+            // Than remove one of the items the parent process should remove and another item for testing.
+            usleep(1000);
+
+            $this->assertTrue($this->_storage->removeItem('prefix_b_key'));
+            $this->assertTrue($this->_storage->removeItem('other'));
+
+            posix_kill(posix_getpid(), SIGTERM);
+        }
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testRaceConditionInClearExpired()
+    {
+        if (!function_exists('pcntl_fork') || !function_exists('posix_kill')) {
+            $this->markTestSkipped('Missing pcntl_fork and/or posix_kill');
+        }
+
+        // delay unlink() by global variable $unlinkDelay
+        global $unlinkDelay;
+        require __DIR__ . '/TestAsset/FilesystemDelayedUnlink.php';
+
+        // create cache items
+        $this->_storage->getOptions()->setDirLevel(0);
+        $this->_storage->getOptions()->setTtl(2);
+        $this->_storage->setItems([
+            'a_key' => 'a_value',
+            'b_key' => 'b_value',
+            'other' => 'other',
+        ]);
+
+        // wait TTL seconds and touch item other so this item will not be deleted by clearExpired
+        // and can be used for testing the child process
+        $this->waitForFullSecond();
+        sleep(2);
+        $this->_storage->touchItem('other');
+
+        $pidChild = pcntl_fork();
+        if ($pidChild == -1) {
+            $this->fail('pcntl_fork() failed');
+        } elseif ($pidChild) {
+            // The parent process
+            // Slow down unlink function and start removing items.
+            // Finally test if the item not matching the tag was removed by the child process.
+            $unlinkDelay = 5000;
+
+            $this->_storage->clearExpired();
+
+            $this->assertFalse($this->_storage->hasItem('a_key'));
+            $this->assertFalse($this->_storage->hasItem('b_key'));
+
+            $this->assertFalse($this->_storage->hasItem('other'), 'Child process does not run as expected');
+        } else {
+            // The child process:
+            // Wait to make sure the parent process has started determining files to unlink.
+            // Than remove one of the items the parent process should remove and another item for testing.
+            usleep(1000);
+
+            $this->assertTrue($this->_storage->removeItem('b_key'));
+            $this->assertTrue($this->_storage->removeItem('other'));
+
+            posix_kill(posix_getpid(), SIGTERM);
+        }
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testRaceConditionInFlush()
+    {
+        if (!function_exists('pcntl_fork') || !function_exists('posix_kill')) {
+            $this->markTestSkipped('Missing pcntl_fork and/or posix_kill');
+        }
+
+        // delay unlink() by global variable $unlinkDelay
+        global $unlinkDelay;
+        require __DIR__ . '/TestAsset/FilesystemDelayedUnlink.php';
+
+        // create cache items
+        $this->_storage->getOptions()->setDirLevel(0);
+        $this->_storage->setItems([
+            'a_key' => 'a_value',
+            'b_key' => 'b_value',
+        ]);
+
+        $pidChild = pcntl_fork();
+        if ($pidChild == -1) {
+            $this->fail('pcntl_fork() failed');
+        } elseif ($pidChild) {
+            // The parent process
+            // Slow down unlink function and start removing items.
+            $unlinkDelay = 5000;
+
+            $this->_storage->flush();
+
+            $this->assertFalse($this->_storage->hasItem('a_key'));
+            $this->assertFalse($this->_storage->hasItem('b_key'));
+        } else {
+            // The child process:
+            // Wait to make sure the parent process has started determining files to unlink.
+            // Than remove one of the items the parent process should remove.
+            usleep(1000);
+
+            $this->assertTrue($this->_storage->removeItem('b_key'));
+
             posix_kill(posix_getpid(), SIGTERM);
         }
     }

--- a/test/Storage/Adapter/TestAsset/FilesystemDelayedUnlink.php
+++ b/test/Storage/Adapter/TestAsset/FilesystemDelayedUnlink.php
@@ -4,10 +4,10 @@ namespace Zend\Cache\Storage\Adapter;
 
 function unlink($path, $context = null)
 {
-    usleep(50000);
-    if ($context) {
-        return \unlink($path, $context);
+    global $unlinkDelay;
+    if (isset($unlinkDelay) && $unlinkDelay > 0) {
+        usleep($unlinkDelay);
     }
 
-    return \unlink($path);
+    return $context ? \unlink($path, $context) : \unlink($path);
 }


### PR DESCRIPTION
found in `clearByNamespace()`, `clearByPrefix()`, `clearExpired()` and `flush()`

this is related to #44 and zendframework/zendframework#7467