### PR TITLE
Move Coverage reporting to latest env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,13 +67,13 @@ matrix:
     - php: 5.6
       env:
         - DEPS=locked
-        - TEST_COVERAGE=true
         - APCU_PECL_VERSION="apcu-4.0.10"
         - DEPLOY_DOCS="$(if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then echo -n 'true' ; else echo -n 'false' ; fi)"
         - PATH="$HOME/.local/bin:$PATH"
     - php: 5.6
       env:
         - DEPS=latest
+        - TEST_COVERAGE=true
         - APCU_PECL_VERSION="apcu-4.0.11"
     - php: 7
       env:


### PR DESCRIPTION
Requiring php-coveralls results in a full update of all dependencies instead of composer installing the versions mentioned in the composer.lock