### PR TITLE
Feature/docblock method chaining consistency

### DIFF
--- a/src/Pattern/AbstractPattern.php
+++ b/src/Pattern/AbstractPattern.php
@@ -22,7 +22,7 @@ abstract class AbstractPattern implements PatternInterface
      * Set pattern options
      *
      * @param  PatternOptions $options
-     * @return AbstractPattern
+     * @return AbstractPattern Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function setOptions(PatternOptions $options)

--- a/src/Pattern/CallbackCache.php
+++ b/src/Pattern/CallbackCache.php
@@ -18,7 +18,7 @@ class CallbackCache extends AbstractPattern
      * Set options
      *
      * @param  PatternOptions $options
-     * @return CallbackCache
+     * @return CallbackCache Provides a fluent interface
      * @throws Exception\InvalidArgumentException if missing storage option
      */
     public function setOptions(PatternOptions $options)

--- a/src/Pattern/ClassCache.php
+++ b/src/Pattern/ClassCache.php
@@ -18,7 +18,7 @@ class ClassCache extends CallbackCache
      * Set options
      *
      * @param  PatternOptions $options
-     * @return ClassCache
+     * @return ClassCache Provides a fluent interface
      * @throws Exception\InvalidArgumentException if missing 'class' or 'storage' options
      */
     public function setOptions(PatternOptions $options)

--- a/src/Pattern/OutputCache.php
+++ b/src/Pattern/OutputCache.php
@@ -24,7 +24,7 @@ class OutputCache extends AbstractPattern
      * Set options
      *
      * @param  PatternOptions $options
-     * @return OutputCache
+     * @return OutputCache Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function setOptions(PatternOptions $options)

--- a/src/Pattern/PatternOptions.php
+++ b/src/Pattern/PatternOptions.php
@@ -168,7 +168,7 @@ class PatternOptions extends AbstractOptions
      * - ObjectCache
      *
      * @param  bool $cacheByDefault
-     * @return PatternOptions
+     * @return PatternOptions Provides a fluent interface
      */
     public function setCacheByDefault($cacheByDefault)
     {
@@ -199,7 +199,7 @@ class PatternOptions extends AbstractOptions
      * - ObjectCache
      *
      * @param  bool $cacheOutput
-     * @return PatternOptions
+     * @return PatternOptions Provides a fluent interface
      */
     public function setCacheOutput($cacheOutput)
     {
@@ -230,7 +230,7 @@ class PatternOptions extends AbstractOptions
      *
      * @param  string $class
      * @throws Exception\InvalidArgumentException
-     * @return PatternOptions
+     * @return PatternOptions Provides a fluent interface
      */
     public function setClass($class)
     {
@@ -261,7 +261,7 @@ class PatternOptions extends AbstractOptions
      * - ClassCache
      *
      * @param  array $classCacheMethods
-     * @return PatternOptions
+     * @return PatternOptions Provides a fluent interface
      */
     public function setClassCacheMethods(array $classCacheMethods)
     {
@@ -289,7 +289,7 @@ class PatternOptions extends AbstractOptions
      * - ClassCache
      *
      * @param  array $classNonCacheMethods
-     * @return PatternOptions
+     * @return PatternOptions Provides a fluent interface
      */
     public function setClassNonCacheMethods(array $classNonCacheMethods)
     {
@@ -315,7 +315,7 @@ class PatternOptions extends AbstractOptions
      *
      * @param  false|int $dirPermission
      * @throws Exception\InvalidArgumentException
-     * @return PatternOptions
+     * @return PatternOptions Provides a fluent interface
      */
     public function setDirPermission($dirPermission)
     {
@@ -356,7 +356,7 @@ class PatternOptions extends AbstractOptions
      *
      * @param  false|int $umask
      * @throws Exception\InvalidArgumentException
-     * @return PatternOptions
+     * @return PatternOptions Provides a fluent interface
      */
     public function setUmask($umask)
     {
@@ -402,7 +402,7 @@ class PatternOptions extends AbstractOptions
      * - CaptureCache
      *
      * @param  bool $fileLocking
-     * @return PatternOptions
+     * @return PatternOptions Provides a fluent interface
      */
     public function setFileLocking($fileLocking)
     {
@@ -428,7 +428,7 @@ class PatternOptions extends AbstractOptions
      *
      * @param  false|int $filePermission
      * @throws Exception\InvalidArgumentException
-     * @return PatternOptions
+     * @return PatternOptions Provides a fluent interface
      */
     public function setFilePermission($filePermission)
     {
@@ -469,7 +469,7 @@ class PatternOptions extends AbstractOptions
      * Set value for index filename
      *
      * @param  string $indexFilename
-     * @return PatternOptions
+     * @return PatternOptions Provides a fluent interface
      */
     public function setIndexFilename($indexFilename)
     {
@@ -492,7 +492,7 @@ class PatternOptions extends AbstractOptions
      *
      * @param  mixed $object
      * @throws Exception\InvalidArgumentException
-     * @return PatternOptions
+     * @return PatternOptions Provides a fluent interface
      */
     public function setObject($object)
     {
@@ -522,7 +522,7 @@ class PatternOptions extends AbstractOptions
      * - ObjectCache
      *
      * @param  bool $objectCacheMagicProperties
-     * @return PatternOptions
+     * @return PatternOptions Provides a fluent interface
      */
     public function setObjectCacheMagicProperties($objectCacheMagicProperties)
     {
@@ -547,7 +547,7 @@ class PatternOptions extends AbstractOptions
      * Set list of object methods for which to cache return values
      *
      * @param  array $objectCacheMethods
-     * @return PatternOptions
+     * @return PatternOptions Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function setObjectCacheMethods(array $objectCacheMethods)
@@ -575,7 +575,7 @@ class PatternOptions extends AbstractOptions
      * - ObjectCache
      *
      * @param  null|string $objectKey The object key or NULL to use the objects class name
-     * @return PatternOptions
+     * @return PatternOptions Provides a fluent interface
      */
     public function setObjectKey($objectKey)
     {
@@ -607,7 +607,7 @@ class PatternOptions extends AbstractOptions
      * Set list of object methods for which NOT to cache return values
      *
      * @param  array $objectNonCacheMethods
-     * @return PatternOptions
+     * @return PatternOptions Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function setObjectNonCacheMethods(array $objectNonCacheMethods)
@@ -634,7 +634,7 @@ class PatternOptions extends AbstractOptions
      *
      * @param  string $publicDir
      * @throws Exception\InvalidArgumentException
-     * @return PatternOptions
+     * @return PatternOptions Provides a fluent interface
      */
     public function setPublicDir($publicDir)
     {
@@ -681,7 +681,7 @@ class PatternOptions extends AbstractOptions
      * - OutputCache
      *
      * @param  string|array|Storage $storage
-     * @return PatternOptions
+     * @return PatternOptions Provides a fluent interface
      */
     public function setStorage($storage)
     {

--- a/src/Storage/Adapter/AbstractAdapter.php
+++ b/src/Storage/Adapter/AbstractAdapter.php
@@ -108,7 +108,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * Set options.
      *
      * @param  array|Traversable|AdapterOptions $options
-     * @return AbstractAdapter
+     * @return AbstractAdapter Provides a fluent interface
      * @see    getOptions()
      */
     public function setOptions($options)
@@ -153,7 +153,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * @see    setWritable()
      * @see    setReadable()
      * @param  bool $flag
-     * @return AbstractAdapter
+     * @return AbstractAdapter Provides a fluent interface
      */
     public function setCaching($flag)
     {
@@ -268,8 +268,8 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * Register a plugin
      *
      * @param  Plugin\PluginInterface $plugin
-     * @param  int                    $priority
-     * @return AbstractAdapter Fluent interface
+     * @param  int $priority
+     * @return AbstractAdapter Provides a fluent interface
      * @throws Exception\LogicException
      */
     public function addPlugin(Plugin\PluginInterface $plugin, $priority = 1)
@@ -292,7 +292,7 @@ abstract class AbstractAdapter implements StorageInterface, EventsCapableInterfa
      * Unregister an already registered plugin
      *
      * @param  Plugin\PluginInterface $plugin
-     * @return AbstractAdapter Fluent interface
+     * @return AbstractAdapter Provides a fluent interface
      * @throws Exception\LogicException
      */
     public function removePlugin(Plugin\PluginInterface $plugin)

--- a/src/Storage/Adapter/AdapterOptions.php
+++ b/src/Storage/Adapter/AdapterOptions.php
@@ -76,7 +76,7 @@ class AdapterOptions extends AbstractOptions
      * Adapter using this instance
      *
      * @param  StorageInterface|null $adapter
-     * @return AdapterOptions
+     * @return AdapterOptions Provides a fluent interface
      */
     public function setAdapter(StorageInterface $adapter = null)
     {
@@ -89,7 +89,7 @@ class AdapterOptions extends AbstractOptions
      *
      * @param  string $keyPattern
      * @throws Exception\InvalidArgumentException
-     * @return AdapterOptions
+     * @return AdapterOptions Provides a fluent interface
      */
     public function setKeyPattern($keyPattern)
     {
@@ -130,7 +130,7 @@ class AdapterOptions extends AbstractOptions
      * Set namespace.
      *
      * @param  string $namespace
-     * @return AdapterOptions
+     * @return AdapterOptions Provides a fluent interface
      */
     public function setNamespace($namespace)
     {
@@ -157,7 +157,7 @@ class AdapterOptions extends AbstractOptions
      * Enable/Disable reading data from cache.
      *
      * @param  bool $readable
-     * @return AbstractAdapter
+     * @return AdapterOptions Provides a fluent interface
      */
     public function setReadable($readable)
     {
@@ -183,7 +183,7 @@ class AdapterOptions extends AbstractOptions
      * Set time to live.
      *
      * @param  int|float $ttl
-     * @return AdapterOptions
+     * @return AdapterOptions Provides a fluent interface
      */
     public function setTtl($ttl)
     {
@@ -209,7 +209,7 @@ class AdapterOptions extends AbstractOptions
      * Enable/Disable writing data to cache.
      *
      * @param  bool $writable
-     * @return AdapterOptions
+     * @return AdapterOptions Provides a fluent interface
      */
     public function setWritable($writable)
     {

--- a/src/Storage/Adapter/ApcIterator.php
+++ b/src/Storage/Adapter/ApcIterator.php
@@ -80,7 +80,7 @@ class ApcIterator implements IteratorInterface
      * Set iterator mode
      *
      * @param int $mode
-     * @return ApcIterator Fluent interface
+     * @return ApcIterator Provides a fluent interface
      */
     public function setMode($mode)
     {

--- a/src/Storage/Adapter/ApcOptions.php
+++ b/src/Storage/Adapter/ApcOptions.php
@@ -25,7 +25,7 @@ class ApcOptions extends AdapterOptions
      * Set namespace separator
      *
      * @param  string $namespaceSeparator
-     * @return ApcOptions
+     * @return ApcOptions Provides a fluent interface
      */
     public function setNamespaceSeparator($namespaceSeparator)
     {

--- a/src/Storage/Adapter/ApcuIterator.php
+++ b/src/Storage/Adapter/ApcuIterator.php
@@ -80,7 +80,7 @@ class ApcuIterator implements IteratorInterface
      * Set iterator mode
      *
      * @param int $mode
-     * @return ApcuIterator Fluent interface
+     * @return ApcuIterator Provides a fluent interface
      */
     public function setMode($mode)
     {

--- a/src/Storage/Adapter/ApcuOptions.php
+++ b/src/Storage/Adapter/ApcuOptions.php
@@ -25,7 +25,7 @@ class ApcuOptions extends AdapterOptions
      * Set namespace separator
      *
      * @param  string $namespaceSeparator
-     * @return ApcuOptions
+     * @return ApcuOptions Provides a fluent interface
      */
     public function setNamespaceSeparator($namespaceSeparator)
     {

--- a/src/Storage/Adapter/BlackHole.php
+++ b/src/Storage/Adapter/BlackHole.php
@@ -71,7 +71,7 @@ class BlackHole implements
      * Set options.
      *
      * @param array|\Traversable|AdapterOptions $options
-     * @return StorageInterface Fluent interface
+     * @return BlackHole Provides a fluent interface
      */
     public function setOptions($options)
     {

--- a/src/Storage/Adapter/DbaIterator.php
+++ b/src/Storage/Adapter/DbaIterator.php
@@ -89,7 +89,7 @@ class DbaIterator implements IteratorInterface
      * Set iterator mode
      *
      * @param int $mode
-     * @return ApcIterator Fluent interface
+     * @return DbaIterator Provides a fluent interface
      */
     public function setMode($mode)
     {

--- a/src/Storage/Adapter/DbaOptions.php
+++ b/src/Storage/Adapter/DbaOptions.php
@@ -48,7 +48,7 @@ class DbaOptions extends AdapterOptions
      * Set namespace separator
      *
      * @param  string $namespaceSeparator
-     * @return DbaOptions
+     * @return DbaOptions Provides a fluent interface
      */
     public function setNamespaceSeparator($namespaceSeparator)
     {
@@ -72,7 +72,7 @@ class DbaOptions extends AdapterOptions
      * Set pathname to database file
      *
      * @param string $pathname
-     * @return DbaOptions
+     * @return DbaOptions Provides a fluent interface
      */
     public function setPathname($pathname)
     {
@@ -95,7 +95,7 @@ class DbaOptions extends AdapterOptions
      *
      *
      * @param string $mode
-     * @return \Zend\Cache\Storage\Adapter\DbaOptions
+     * @return DbaOptions Provides a fluent interface
      */
     public function setMode($mode)
     {
@@ -109,6 +109,12 @@ class DbaOptions extends AdapterOptions
         return $this->mode;
     }
 
+    /**
+     *
+     *
+     * @param string $handler
+     * @return DbaOptions Provides a fluent interface
+     */
     public function setHandler($handler)
     {
         $handler = (string) $handler;

--- a/src/Storage/Adapter/FilesystemIterator.php
+++ b/src/Storage/Adapter/FilesystemIterator.php
@@ -88,7 +88,7 @@ class FilesystemIterator implements IteratorInterface
      * Set iterator mode
      *
      * @param int $mode
-     * @return FilesystemIterator Fluent interface
+     * @return FilesystemIterator Provides a fluent interface
      */
     public function setMode($mode)
     {

--- a/src/Storage/Adapter/FilesystemOptions.php
+++ b/src/Storage/Adapter/FilesystemOptions.php
@@ -119,7 +119,7 @@ class FilesystemOptions extends AdapterOptions
      * Set cache dir
      *
      * @param  string $cacheDir
-     * @return FilesystemOptions
+     * @return FilesystemOptions Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function setCacheDir($cacheDir)
@@ -167,7 +167,7 @@ class FilesystemOptions extends AdapterOptions
      * Set clear stat cache
      *
      * @param  bool $clearStatCache
-     * @return FilesystemOptions
+     * @return FilesystemOptions Provides a fluent interface
      */
     public function setClearStatCache($clearStatCache)
     {
@@ -191,7 +191,7 @@ class FilesystemOptions extends AdapterOptions
      * Set dir level
      *
      * @param  int $dirLevel
-     * @return FilesystemOptions
+     * @return FilesystemOptions Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function setDirLevel($dirLevel)
@@ -221,7 +221,7 @@ class FilesystemOptions extends AdapterOptions
      * Set permission to create directories on unix systems
      *
      * @param false|string|int $dirPermission FALSE to disable explicit permission or an octal number
-     * @return FilesystemOptions
+     * @return FilesystemOptions Provides a fluent interface
      * @see setUmask
      * @see setFilePermission
      * @link http://php.net/manual/function.chmod.php
@@ -265,7 +265,7 @@ class FilesystemOptions extends AdapterOptions
      * Set file locking
      *
      * @param  bool $fileLocking
-     * @return FilesystemOptions
+     * @return FilesystemOptions Provides a fluent interface
      */
     public function setFileLocking($fileLocking)
     {
@@ -289,7 +289,7 @@ class FilesystemOptions extends AdapterOptions
      * Set permission to create files on unix systems
      *
      * @param false|string|int $filePermission FALSE to disable explicit permission or an octal number
-     * @return FilesystemOptions
+     * @return FilesystemOptions Provides a fluent interface
      * @see setUmask
      * @see setDirPermission
      * @link http://php.net/manual/function.chmod.php
@@ -337,7 +337,7 @@ class FilesystemOptions extends AdapterOptions
      * Set namespace separator
      *
      * @param  string $namespaceSeparator
-     * @return FilesystemOptions
+     * @return FilesystemOptions Provides a fluent interface
      */
     public function setNamespaceSeparator($namespaceSeparator)
     {
@@ -361,7 +361,7 @@ class FilesystemOptions extends AdapterOptions
      * Set no atime
      *
      * @param  bool $noAtime
-     * @return FilesystemOptions
+     * @return FilesystemOptions Provides a fluent interface
      */
     public function setNoAtime($noAtime)
     {

--- a/src/Storage/Adapter/KeyListIterator.php
+++ b/src/Storage/Adapter/KeyListIterator.php
@@ -87,7 +87,7 @@ class KeyListIterator implements IteratorInterface, Countable
      * Set iterator mode
      *
      * @param int $mode
-     * @return KeyListIterator Fluent interface
+     * @return KeyListIterator Provides a fluent interface
      */
     public function setMode($mode)
     {

--- a/src/Storage/Adapter/MemcacheResourceManager.php
+++ b/src/Storage/Adapter/MemcacheResourceManager.php
@@ -97,7 +97,7 @@ class MemcacheResourceManager
      * @param array|Traversable|MemcacheResource $resource
      * @param callable $failureCallback
      * @param array|Traversable $serverDefaults
-     * @return MemcacheResourceManager
+     * @return MemcacheResourceManager Provides a fluent interface
      */
     public function setResource($id, $resource, $failureCallback = null, $serverDefaults = [])
     {
@@ -153,7 +153,7 @@ class MemcacheResourceManager
      * Remove a resource
      *
      * @param string $id
-     * @return MemcacheResourceManager
+     * @return MemcacheResourceManager Provides a fluent interface
      */
     public function removeResource($id)
     {
@@ -228,7 +228,7 @@ class MemcacheResourceManager
      * @param string                            $id
      * @param int|string|array|ArrayAccess|null $threshold
      * @param float|string|bool                 $minSavings
-     * @return MemcacheResourceManager
+     * @return MemcacheResourceManager Provides a fluent interface
      */
     public function setAutoCompressThreshold($id, $threshold, $minSavings = false)
     {
@@ -278,7 +278,7 @@ class MemcacheResourceManager
      *
      * @param  string            $id
      * @param  float|string|null $minSavings
-     * @return MemcacheResourceManager
+     * @return MemcacheResourceManager Provides a fluent interface
      * @throws \Zend\Cache\Exception\RuntimeException
      */
     public function setAutoCompressMinSavings($id, $minSavings)
@@ -310,7 +310,7 @@ class MemcacheResourceManager
      * )
      * @param string $id
      * @param array  $serverDefaults
-     * @return MemcacheResourceManager
+     * @return MemcacheResourceManager Provides a fluent interface
      */
     public function setServerDefaults($id, array $serverDefaults)
     {
@@ -383,7 +383,7 @@ class MemcacheResourceManager
      *
      * @param string $id
      * @param callable|null $failureCallback
-     * @return MemcacheResourceManager
+     * @return MemcacheResourceManager Provides a fluent interface
      */
     public function setFailureCallback($id, $failureCallback)
     {
@@ -435,7 +435,7 @@ class MemcacheResourceManager
      *
      * @param string       $id
      * @param string|array $servers
-     * @return MemcacheResourceManager
+     * @return MemcacheResourceManager Provides a fluent interface
      */
     public function addServers($id, $servers)
     {

--- a/src/Storage/Adapter/MemcachedOptions.php
+++ b/src/Storage/Adapter/MemcachedOptions.php
@@ -72,7 +72,7 @@ class MemcachedOptions extends AdapterOptions
      * Set namespace separator
      *
      * @param  string $namespaceSeparator
-     * @return MemcachedOptions
+     * @return MemcachedOptions Provides a fluent interface
      */
     public function setNamespaceSeparator($namespaceSeparator)
     {
@@ -98,7 +98,7 @@ class MemcachedOptions extends AdapterOptions
      * A memcached resource to share
      *
      * @param null|MemcachedResource $memcachedResource
-     * @return MemcachedOptions
+     * @return MemcachedOptions Provides a fluent interface
      * @deprecated Please use the resource manager instead
      */
     public function setMemcachedResource(MemcachedResource $memcachedResource = null)
@@ -139,7 +139,7 @@ class MemcachedOptions extends AdapterOptions
      * Set the memcached resource manager to use
      *
      * @param null|MemcachedResourceManager $resourceManager
-     * @return MemcachedOptions
+     * @return MemcachedOptions Provides a fluent interface
      */
     public function setResourceManager(MemcachedResourceManager $resourceManager = null)
     {
@@ -177,7 +177,7 @@ class MemcachedOptions extends AdapterOptions
      * Set the memcached resource id
      *
      * @param string $resourceId
-     * @return MemcachedOptions
+     * @return MemcachedOptions Provides a fluent interface
      */
     public function setResourceId($resourceId)
     {
@@ -203,7 +203,7 @@ class MemcachedOptions extends AdapterOptions
      * Set the persistent id
      *
      * @param string $persistentId
-     * @return MemcachedOptions
+     * @return MemcachedOptions Provides a fluent interface
      */
     public function setPersistentId($persistentId)
     {
@@ -218,7 +218,7 @@ class MemcachedOptions extends AdapterOptions
      * @param string $host
      * @param int $port
      * @param int $weight
-     * @return MemcachedOptions
+     * @return MemcachedOptions Provides a fluent interface
      * @deprecated Please use the resource manager instead
      */
     public function addServer($host, $port = 11211, $weight = 0)
@@ -242,7 +242,7 @@ class MemcachedOptions extends AdapterOptions
     * Set a list of memcached servers to add on initialize
     *
     * @param string|array $servers list of servers
-    * @return MemcachedOptions
+    * @return MemcachedOptions Provides a fluent interface
     * @throws Exception\InvalidArgumentException
     */
     public function setServers($servers)
@@ -265,7 +265,7 @@ class MemcachedOptions extends AdapterOptions
     * Set libmemcached options
     *
     * @param array $libOptions
-    * @return MemcachedOptions
+    * @return MemcachedOptions Provides a fluent interface
     * @link http://php.net/manual/memcached.constants.php
     */
     public function setLibOptions(array $libOptions)
@@ -279,7 +279,7 @@ class MemcachedOptions extends AdapterOptions
      *
      * @param string|int $key
      * @param mixed $value
-     * @return MemcachedOptions
+     * @return MemcachedOptions Provides a fluent interface
      * @link http://php.net/manual/memcached.constants.php
      * @deprecated Please use lib_options or the resource manager instead
      */

--- a/src/Storage/Adapter/MemcachedResourceManager.php
+++ b/src/Storage/Adapter/MemcachedResourceManager.php
@@ -173,7 +173,7 @@ class MemcachedResourceManager
      *
      * @param string $id
      * @param array|Traversable|MemcachedResource $resource
-     * @return MemcachedResourceManager Fluent interface
+     * @return MemcachedResourceManager Provides a fluent interface
      */
     public function setResource($id, $resource)
     {
@@ -208,7 +208,7 @@ class MemcachedResourceManager
      * Remove a resource
      *
      * @param string $id
-     * @return MemcachedResourceManager Fluent interface
+     * @return MemcachedResourceManager Provides a fluent interface
      */
     public function removeResource($id)
     {
@@ -221,7 +221,7 @@ class MemcachedResourceManager
      *
      * @param string $id
      * @param string $persistentId
-     * @return MemcachedResourceManager Fluent interface
+     * @return MemcachedResourceManager Provides a fluent interface
      * @throws Exception\RuntimeException
      */
     public function setPersistentId($id, $persistentId)
@@ -284,7 +284,7 @@ class MemcachedResourceManager
      *
      * @param string $id
      * @param array  $libOptions
-     * @return MemcachedResourceManager Fluent interface
+     * @return MemcachedResourceManager Provides a fluent interface
      */
     public function setLibOptions($id, array $libOptions)
     {
@@ -432,7 +432,7 @@ class MemcachedResourceManager
      *
      * @param string       $id
      * @param string|array $servers
-     * @return MemcachedResourceManager
+     * @return MemcachedResourceManager Provides a fluent interface
      */
     public function setServers($id, $servers)
     {
@@ -463,7 +463,7 @@ class MemcachedResourceManager
      *
      * @param string       $id
      * @param string|array $servers
-     * @return MemcachedResourceManager
+     * @return MemcachedResourceManager Provides a fluent interface
      */
     public function addServers($id, $servers)
     {

--- a/src/Storage/Adapter/MemoryOptions.php
+++ b/src/Storage/Adapter/MemoryOptions.php
@@ -33,7 +33,7 @@ class MemoryOptions extends AdapterOptions
      *
      * @link http://php.net/manual/faq.using.php#faq.using.shorthandbytes
      * @param  string|int $memoryLimit
-     * @return MemoryOptions
+     * @return MemoryOptions Provides a fluent interface
      */
     public function setMemoryLimit($memoryLimit)
     {

--- a/src/Storage/Adapter/MongoDbOptions.php
+++ b/src/Storage/Adapter/MongoDbOptions.php
@@ -45,7 +45,7 @@ class MongoDbOptions extends AdapterOptions
      *
      * @param  string $namespaceSeparator
      *
-     * @return self
+     * @return MongoDbOptions Provides a fluent interface
      */
     public function setNamespaceSeparator($namespaceSeparator)
     {
@@ -75,7 +75,7 @@ class MongoDbOptions extends AdapterOptions
      *
      * @param null|MongoDbResourceManager $resourceManager
      *
-     * @return self
+     * @return MongoDbOptions Provides a fluent interface
      */
     public function setResourceManager(MongoDbResourceManager $resourceManager = null)
     {
@@ -113,7 +113,7 @@ class MongoDbOptions extends AdapterOptions
      *
      * @param string $resourceId
      *
-     * @return self
+     * @return MongoDbOptions Provides a fluent interface
      */
     public function setResourceId($resourceId)
     {
@@ -132,7 +132,8 @@ class MongoDbOptions extends AdapterOptions
      * Set the mongo DB server
      *
      * @param string $server
-     * @return self
+     *
+     * @return MongoDbOptions Provides a fluent interface
      */
     public function setServer($server)
     {
@@ -140,24 +141,52 @@ class MongoDbOptions extends AdapterOptions
         return $this;
     }
 
+    /**
+     *
+     *
+     * @param array $connectionOptions
+     *
+     * @return MongoDbOptions Provides a fluent interface
+     */
     public function setConnectionOptions(array $connectionOptions)
     {
         $this->getResourceManager()->setConnectionOptions($this->getResourceId(), $connectionOptions);
         return $this;
     }
 
+    /**
+     *
+     *
+     * @param array $driverOptions
+    MongoDbOptions
+     * @return MongoDbOptions Provides a fluent interface
+     */
     public function setDriverOptions(array $driverOptions)
     {
         $this->getResourceManager()->setDriverOptions($this->getResourceId(), $driverOptions);
         return $this;
     }
 
+    /**
+     *
+     *
+     * @param string $database
+     *
+     * @return MongoDbOptions Provides a fluent interface
+     */
     public function setDatabase($database)
     {
         $this->getResourceManager()->setDatabase($this->getResourceId(), $database);
         return $this;
     }
 
+    /**
+     *
+     *
+     * @param string $collection
+     *
+     * @return MongoDbOptions Provides a fluent interface
+     */
     public function setCollection($collection)
     {
         $this->getResourceManager()->setCollection($this->getResourceId(), $collection);

--- a/src/Storage/Adapter/MongoDbResourceManager.php
+++ b/src/Storage/Adapter/MongoDbResourceManager.php
@@ -40,7 +40,7 @@ class MongoDbResourceManager
      * @param string $id
      * @param array|MongoCollection $resource
      *
-     * @return self
+     * @return MongoDbResourceManager Provides a fluent interface
      *
      * @throws Exception\RuntimeException
      */

--- a/src/Storage/Adapter/RedisOptions.php
+++ b/src/Storage/Adapter/RedisOptions.php
@@ -71,7 +71,7 @@ class RedisOptions extends AdapterOptions
      * Set namespace separator
      *
      * @param  string $namespaceSeparator
-     * @return RedisOptions
+     * @return RedisOptions Provides a fluent interface
      */
     public function setNamespaceSeparator($namespaceSeparator)
     {
@@ -97,7 +97,7 @@ class RedisOptions extends AdapterOptions
      * Set the redis resource manager to use
      *
      * @param null|RedisResourceManager $resourceManager
-     * @return RedisOptions
+     * @return RedisOptions Provides a fluent interface
      */
     public function setResourceManager(RedisResourceManager $resourceManager = null)
     {
@@ -135,7 +135,7 @@ class RedisOptions extends AdapterOptions
      * Set the redis resource id
      *
      * @param string $resourceId
-     * @return RedisOptions
+     * @return RedisOptions Provides a fluent interface
      */
     public function setResourceId($resourceId)
     {
@@ -161,7 +161,7 @@ class RedisOptions extends AdapterOptions
      * Set the persistent id
      *
      * @param string $persistentId
-     * @return RedisOptions
+     * @return RedisOptions Provides a fluent interface
      */
     public function setPersistentId($persistentId)
     {
@@ -174,7 +174,7 @@ class RedisOptions extends AdapterOptions
     * Set redis options
     *
     * @param array $libOptions
-    * @return RedisOptions
+    * @return RedisOptions Provides a fluent interface
     * @link http://github.com/nicolasff/phpredis#setoption
     */
     public function setLibOptions(array $libOptions)
@@ -205,7 +205,7 @@ class RedisOptions extends AdapterOptions
      *
      * @param string|array $server
      *
-     * @return RedisOptions
+     * @return RedisOptions Provides a fluent interface
      */
     public function setServer($server)
     {
@@ -228,7 +228,7 @@ class RedisOptions extends AdapterOptions
      *
      * @param int $database Database number
      *
-     * @return RedisOptions
+     * @return RedisOptions Provides a fluent interface
      */
     public function setDatabase($database)
     {
@@ -251,7 +251,7 @@ class RedisOptions extends AdapterOptions
      *
      * @param string $password Password
      *
-     * @return RedisOptions
+     * @return RedisOptions Provides a fluent interface
      */
     public function setPassword($password)
     {

--- a/src/Storage/Adapter/SessionOptions.php
+++ b/src/Storage/Adapter/SessionOptions.php
@@ -27,7 +27,7 @@ class SessionOptions extends AdapterOptions
      * Set the session container
      *
      * @param  null|SessionContainer $sessionContainer
-     * @return SessionOptions
+     * @return SessionOptions Provides a fluent interface
      */
     public function setSessionContainer(SessionContainer $sessionContainer = null)
     {

--- a/src/Storage/Adapter/XCacheOptions.php
+++ b/src/Storage/Adapter/XCacheOptions.php
@@ -46,7 +46,7 @@ class XCacheOptions extends AdapterOptions
      * Set namespace separator
      *
      * @param  string $namespaceSeparator
-     * @return XCacheOptions
+     * @return XCacheOptions Provides a fluent interface
      */
     public function setNamespaceSeparator($namespaceSeparator)
     {
@@ -70,7 +70,7 @@ class XCacheOptions extends AdapterOptions
      * Set username to call admin functions
      *
      * @param  null|string $adminUser
-     * @return XCacheOptions
+     * @return XCacheOptions Provides a fluent interface
      */
     public function setAdminUser($adminUser)
     {
@@ -96,7 +96,7 @@ class XCacheOptions extends AdapterOptions
      * Enable/Disable admin authentication handling
      *
      * @param  bool $adminAuth
-     * @return XCacheOptions
+     * @return XCacheOptions Provides a fluent interface
      */
     public function setAdminAuth($adminAuth)
     {
@@ -122,7 +122,7 @@ class XCacheOptions extends AdapterOptions
      * Set password to call admin functions
      *
      * @param  null|string $adminPass
-     * @return XCacheOptions
+     * @return XCacheOptions Provides a fluent interface
      */
     public function setAdminPass($adminPass)
     {

--- a/src/Storage/Plugin/AbstractPlugin.php
+++ b/src/Storage/Plugin/AbstractPlugin.php
@@ -22,7 +22,7 @@ abstract class AbstractPlugin extends AbstractListenerAggregate implements Plugi
      * Set pattern options
      *
      * @param  PluginOptions $options
-     * @return AbstractPlugin
+     * @return AbstractPlugin Provides a fluent interface
      */
     public function setOptions(PluginOptions $options)
     {

--- a/src/Storage/Plugin/PluginOptions.php
+++ b/src/Storage/Plugin/PluginOptions.php
@@ -72,7 +72,7 @@ class PluginOptions extends AbstractOptions
      * - ClearExpiredByFactor
      *
      * @param  int $clearingFactor
-     * @return PluginOptions
+     * @return PluginOptions Provides a fluent interface
      */
     public function setClearingFactor($clearingFactor)
     {
@@ -101,7 +101,7 @@ class PluginOptions extends AbstractOptions
      *
      * @param  null|callable $exceptionCallback
      * @throws Exception\InvalidArgumentException
-     * @return PluginOptions
+     * @return PluginOptions Provides a fluent interface
      */
     public function setExceptionCallback($exceptionCallback)
     {
@@ -129,7 +129,7 @@ class PluginOptions extends AbstractOptions
      * Exit if connection aborted and ignore_user_abort is disabled.
      *
      * @param  bool $exitOnAbort
-     * @return PluginOptions
+     * @return PluginOptions Provides a fluent interface
      */
     public function setExitOnAbort($exitOnAbort)
     {
@@ -154,7 +154,7 @@ class PluginOptions extends AbstractOptions
      * - OptimizeByFactor
      *
      * @param  int $optimizingFactor
-     * @return PluginOptions
+     * @return PluginOptions Provides a fluent interface
      */
     public function setOptimizingFactor($optimizingFactor)
     {
@@ -183,7 +183,7 @@ class PluginOptions extends AbstractOptions
      *
      * @param  string|SerializerAdapter $serializer
      * @throws Exception\InvalidArgumentException
-     * @return self
+     * @return PluginOptions Provides a fluent interface
      */
     public function setSerializer($serializer)
     {
@@ -229,7 +229,7 @@ class PluginOptions extends AbstractOptions
      * - Serializer
      *
      * @param  mixed $serializerOptions
-     * @return PluginOptions
+     * @return PluginOptions Provides a fluent interface
      */
     public function setSerializerOptions($serializerOptions)
     {
@@ -257,7 +257,7 @@ class PluginOptions extends AbstractOptions
      * - ExceptionHandler
      *
      * @param  bool $throwExceptions
-     * @return PluginOptions
+     * @return PluginOptions Provides a fluent interface
      */
     public function setThrowExceptions($throwExceptions)
     {


### PR DESCRIPTION
As discussed in [fluent interface return type vs return self #7193](https://github.com/zendframework/zendframework/issues/7193), this changes remove occurrences of class names and self keyword from the DocBlocks
