### PR TITLE
We don't need call info method every time we want redis resource. +1

### DIFF
--- a/src/Storage/Adapter/RedisResourceManager.php
+++ b/src/Storage/Adapter/RedisResourceManager.php
@@ -118,7 +118,7 @@ class RedisResourceManager
      * Gets a redis resource
      *
      * @param string $id
-     * @return RedisResourceManager
+     * @return RedisResource
      * @throws Exception\RuntimeException
      */
     public function getResource($id)
@@ -133,8 +133,12 @@ class RedisResourceManager
             if (!$resource['initialized']) {
                 $this->connect($resource);
             }
-            $info = $resource['resource']->info();
-            $resource['version'] = $info['redis_version'];
+
+            if (!$resource['version']) {
+                $info = $resource['resource']->info();
+                $resource['version'] = $info['redis_version'];
+            }
+
             return $resource['resource'];
         }
 


### PR DESCRIPTION
Fix https://github.com/zendframework/zend-cache/pull/100

 The `$resource['version']` can be set only once.

``` php
            if (!$resource['initialized']) {
                $this->connect($resource);
            }

            if (!$resource['version']) { //If version is not set .
                $info = $resource['resource']->info();
                $resource['version'] = $info['redis_version'];
            }

            return $resource['resource'];
```
