### PR TITLE
Adding option to change cache and tag file suffixes

### DIFF
--- a/doc/book/storage/adapter.md
+++ b/doc/book/storage/adapter.md
@@ -651,6 +651,8 @@ Name | Data Type | Default Value | Description
 `no_atime` | `boolean` | `true` | Don’t get ‘fileatime’ as ‘atime’ on metadata.
 `no_ctime` | `boolean` | `true` | Don’t get ‘filectime’ as ‘ctime’ on metadata.
 `umask` | `integer|false` | `false` | Use [umask](http://wikipedia.org/wiki/Umask) to set file and directory permissions.
+`suffix` | `string` | `dat` | Suffix for cache files
+`tag_suffix` | `string` | `tag` | Suffix for tag files
 
 ## The Memcached Adapter
 

--- a/doc/book/storage/adapter.md
+++ b/doc/book/storage/adapter.md
@@ -654,6 +654,9 @@ Name | Data Type | Default Value | Description
 `suffix` | `string` | `dat` | Suffix for cache files
 `tag_suffix` | `string` | `tag` | Suffix for tag files
 
+Note: the `suffix` and `tag_suffix` options will be escaped in order to be safe
+for glob operations.
+
 ## The Memcached Adapter
 
 `Zend\Cache\Storage\Adapter\Memcached` stores cache items over the memcached

--- a/src/Storage/Adapter/Filesystem.php
+++ b/src/Storage/Adapter/Filesystem.php
@@ -1246,7 +1246,6 @@ class Filesystem extends AbstractAdapter implements
                     'maxTtl'             => 0,
                     'staticTtl'          => false,
                     'ttlPrecision'       => 1,
-                    'expiredRead'        => true,
                     'maxKeyLength'       => $maxKeyLength,
                     'namespaceIsPrefix'  => true,
                     'namespaceSeparator' => $options->getNamespaceSeparator(),

--- a/src/Storage/Adapter/Filesystem.php
+++ b/src/Storage/Adapter/Filesystem.php
@@ -698,7 +698,7 @@ class Filesystem extends AbstractAdapter implements
      */
     protected function internalHasItem(& $normalizedKey)
     {
-        $file = $this->formatFilename($this->getFileContent($normalizedKey));
+        $file = $this->formatFilename($this->getFileSpec($normalizedKey));
         if (! file_exists($file)) {
             return false;
         }

--- a/src/Storage/Adapter/FilesystemOptions.php
+++ b/src/Storage/Adapter/FilesystemOptions.php
@@ -98,6 +98,20 @@ class FilesystemOptions extends AdapterOptions
     protected $umask = false;
 
     /**
+     * Suffix for cache files
+     *
+     * @var string
+     */
+    protected $suffix = 'dat';
+
+    /**
+     * Suffix for tag files
+     *
+     * @var string
+     */
+    protected $tagSuffix = 'tag';
+
+    /**
      * Constructor
      *
      * @param  array|Traversable|null $options
@@ -454,4 +468,50 @@ class FilesystemOptions extends AdapterOptions
     {
         return $this->umask;
     }
+
+    /**
+     * Get the suffix for cache files
+     *
+     * @return string
+     */
+    public function getSuffix()
+    {
+        return $this->suffix;
+    }
+
+    /**
+     * Set the suffix for cache files
+     *
+     * @param string $suffix
+     */
+    public function setSuffix($suffix)
+    {
+        $this->suffix = $suffix;
+
+        return $this;
+    }
+
+    /**
+     * Get the suffix for tag files
+     *
+     * @return the $tagSuffix
+     */
+    public function getTagSuffix()
+    {
+        return $this->tagSuffix;
+    }
+
+    /**
+     * Set the suffix for cache files
+     *
+     * @param string $tagSuffix
+     */
+    public function setTagSuffix($tagSuffix)
+    {
+        $this->tagSuffix = $tagSuffix;
+
+        return $this;
+    }
+
+
 }

--- a/src/Storage/Adapter/FilesystemOptions.php
+++ b/src/Storage/Adapter/FilesystemOptions.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2005-2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-cache/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\Cache\Storage\Adapter;
@@ -487,7 +485,6 @@ class FilesystemOptions extends AdapterOptions
     public function setSuffix($suffix)
     {
         $this->suffix = $suffix;
-
         return $this;
     }
 
@@ -509,7 +506,6 @@ class FilesystemOptions extends AdapterOptions
     public function setTagSuffix($tagSuffix)
     {
         $this->tagSuffix = $tagSuffix;
-
         return $this;
     }
 }

--- a/src/Storage/Adapter/FilesystemOptions.php
+++ b/src/Storage/Adapter/FilesystemOptions.php
@@ -512,6 +512,4 @@ class FilesystemOptions extends AdapterOptions
 
         return $this;
     }
-
-
 }

--- a/test/Storage/Adapter/FilesystemTest.php
+++ b/test/Storage/Adapter/FilesystemTest.php
@@ -610,5 +610,4 @@ class FilesystemTest extends CommonAdapterTest
         $this->_options->setTagSuffix('.cache');
         $this->assertSame('.cache', $this->_options->getTagSuffix());
     }
-
 }

--- a/test/Storage/Adapter/FilesystemTest.php
+++ b/test/Storage/Adapter/FilesystemTest.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2005-2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-cache/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\Cache\Storage\Adapter;
@@ -599,13 +597,13 @@ class FilesystemTest extends CommonAdapterTest
         }
     }
 
-    public function testSetSuffix()
+    public function testSuffixIsMutable()
     {
         $this->_options->setSuffix('.cache');
         $this->assertSame('.cache', $this->_options->getSuffix());
     }
 
-    public function testSetTagSuffix()
+    public function testTagSuffixIsMutable()
     {
         $this->_options->setTagSuffix('.cache');
         $this->assertSame('.cache', $this->_options->getTagSuffix());

--- a/test/Storage/Adapter/FilesystemTest.php
+++ b/test/Storage/Adapter/FilesystemTest.php
@@ -598,4 +598,17 @@ class FilesystemTest extends CommonAdapterTest
             posix_kill(posix_getpid(), SIGTERM);
         }
     }
+
+    public function testSetSuffix()
+    {
+        $this->_options->setSuffix('.cache');
+        $this->assertSame('.cache', $this->_options->getSuffix());
+    }
+
+    public function testSetTagSuffix()
+    {
+        $this->_options->setTagSuffix('.cache');
+        $this->assertSame('.cache', $this->_options->getTagSuffix());
+    }
+
 }


### PR DESCRIPTION
With this PR we can change the suffix for cache files. One use case is to use the filesystem cache to generate zend-view files (phtml suffixes).
