### PR TITLE
Deprecate capability "expiredRead"

### DIFF
--- a/doc/book/storage/adapter.md
+++ b/doc/book/storage/adapter.md
@@ -550,7 +550,6 @@ Capability | Value
 `staticTtl` | `true`
 `ttlPrecision` | 1
 `useRequestTime` | value of `apc.use_request_time` from `php.ini`
-`expiredRead` | `false`
 `maxKeyLength` | 5182
 `namespaceIsPrefix` | `true`
 `namespaceSeparator` | Option value of `namespace_separator`
@@ -631,7 +630,6 @@ Capability | Value
 `staticTtl` | `false`
 `ttlPrecision` | 1
 `useRequestTime` | `false`
-`expiredRead` | `true`
 `maxKeyLength` | 251
 `namespaceIsPrefix` | `true`
 `namespaceSeparator` | Option value of `namespace_separator`
@@ -676,7 +674,6 @@ Capability | Value
 `staticTtl` | `true`
 `ttlPrecision` | 1
 `useRequestTime` | `false`
-`expiredRead` | `false`
 `maxKeyLength` | 255
 `namespaceIsPrefix` | `true`
 `namespaceSeparator` | none
@@ -709,7 +706,6 @@ Capability | Value
 `staticTtl` | `true`
 `ttlPrecision` | 1
 `useRequestTime` | `false`
-`expiredRead` | `false`
 `maxKeyLength` | 255
 `namespaceIsPrefix` | `true`
 `namespaceSeparator` | none
@@ -759,7 +755,6 @@ Capability | Value
 `staticTtl` | `false`
 `ttlPrecision` | 0.05
 `useRequestTime` | `false`
-`expiredRead` | `true`
 `maxKeyLength` | 0
 `namespaceIsPrefix` | `false`
 
@@ -796,18 +791,17 @@ This adapter implements the following interfaces:
 
 ### Capabilities
 
-Capability  Value
-supportedDatatypes  null, boolean, integer, double, string, array
-supportedMetadata   _id
-minTtl  0
-maxTtl  0
-staticTtl   true
-ttlPrecision    1
-useRequestTime  false
-expiredRead false
-maxKeyLength    255
-namespaceIsPrefix   true
-namespaceSeparator  <Option value of namespace_separator>
+Capability | Value
+---------- | -----
+`supportedDatatypes` | `string`, `null`, `boolean`, `integer`, `double`, `array`
+`supportedMetadata` | _id
+`minTtl` | 0
+`maxTtl` | 0
+`staticTtl` | `true`
+`ttlPrecision` | 1
+`useRequestTime` | `false`
+`maxKeyLength` | 255
+`namespaceIsPrefix` | <Option value of namespace_separator>
 
 ### Adapter specific options
 
@@ -849,7 +843,6 @@ Capability | Value
 `staticTtl` | `true`
 `ttlPrecision` | 1
 `useRequestTime` | `apc.use_request_time` `php.ini` value.
-`expiredRead` | `false`
 `namespaceIsPrefix` | `true`
 `namespaceSeparator` | Option value of `namespace_separator`
 
@@ -885,7 +878,6 @@ Capability | Value
 `staticTtl` | `true`
 `ttlPrecision` | 1
 `useRequestTime` | `true`
-`expiredRead` | `false`
 `maxKeyLength` | 5182
 `namespaceIsPrefix` | `true`
 `namespaceSeparator` | Option value of `namespace_separator`
@@ -924,7 +916,6 @@ Capability | Value
 `staticTtl` | `true`
 `ttlPrecision` | 1
 `useRequestTime` | `false`
-`expiredRead` | `false`
 `namespaceIsPrefix` | `true`
 `namespaceSeparator` | `::`
 
@@ -952,7 +943,6 @@ Capability | Value
 `staticTtl` | `true`
 `ttlPrecision` | 1
 `useRequestTime` | `false`
-`expiredRead` | `false`
 `namespaceIsPrefix` | `true`
 `namespaceSeparator` | `::`
 

--- a/doc/book/storage/capabilities.md
+++ b/doc/book/storage/capabilities.md
@@ -170,6 +170,8 @@ class Capabilities
      * Get if expired items are readable
      *
      * @return bool
+     * @deprecated This capability has been deprecated and will be removed in the future.
+     *             Please use getStaticTtl() instead
      */
     public function getExpiredRead();
 
@@ -179,6 +181,8 @@ class Capabilities
      * @param  stdClass $marker
      * @param  bool $flag
      * @return Capabilities Fluent interface
+     * @deprecated This capability has been deprecated and will be removed in the future.
+     *             Please use setStaticTtl() instead
      */
     public function setExpiredRead(stdClass $marker, $flag);
 

--- a/src/Storage/Adapter/AbstractZendServer.php
+++ b/src/Storage/Adapter/AbstractZendServer.php
@@ -221,7 +221,6 @@ abstract class AbstractZendServer extends AbstractAdapter
                     'staticTtl'          => true,
                     'ttlPrecision'       => 1,
                     'useRequestTime'     => false,
-                    'expiredRead'        => false,
                     'maxKeyLength'       => 0,
                     'namespaceIsPrefix'  => true,
                     'namespaceSeparator' => self::NAMESPACE_SEPARATOR,

--- a/src/Storage/Adapter/Apc.php
+++ b/src/Storage/Adapter/Apc.php
@@ -687,7 +687,6 @@ class Apc extends AbstractAdapter implements
                     'staticTtl'          => true,
                     'ttlPrecision'       => 1,
                     'useRequestTime'     => (bool) ini_get('apc.use_request_time'),
-                    'expiredRead'        => false,
                     'maxKeyLength'       => 5182,
                     'namespaceIsPrefix'  => true,
                     'namespaceSeparator' => $this->getOptions()->getNamespaceSeparator(),

--- a/src/Storage/Adapter/Apcu.php
+++ b/src/Storage/Adapter/Apcu.php
@@ -692,7 +692,6 @@ class Apcu extends AbstractAdapter implements
                     'staticTtl'          => true,
                     'ttlPrecision'       => 1,
                     'useRequestTime'     => (bool) ini_get('apc.use_request_time'),
-                    'expiredRead'        => false,
                     'maxKeyLength'       => 5182,
                     'namespaceIsPrefix'  => true,
                     'namespaceSeparator' => $this->getOptions()->getNamespaceSeparator(),

--- a/src/Storage/Adapter/Filesystem.php
+++ b/src/Storage/Adapter/Filesystem.php
@@ -1223,7 +1223,6 @@ class Filesystem extends AbstractAdapter implements
                     'maxTtl'             => 0,
                     'staticTtl'          => false,
                     'ttlPrecision'       => 1,
-                    'expiredRead'        => true,
                     'maxKeyLength'       => 251, // 255 - strlen(.dat | .tag)
                     'namespaceIsPrefix'  => true,
                     'namespaceSeparator' => $options->getNamespaceSeparator(),

--- a/src/Storage/Adapter/Memcache.php
+++ b/src/Storage/Adapter/Memcache.php
@@ -538,7 +538,6 @@ class Memcache extends AbstractAdapter implements
                 'staticTtl'          => true,
                 'ttlPrecision'       => 1,
                 'useRequestTime'     => false,
-                'expiredRead'        => false,
                 'maxKeyLength'       => 255,
                 'namespaceIsPrefix'  => true,
             ]

--- a/src/Storage/Adapter/Memcached.php
+++ b/src/Storage/Adapter/Memcached.php
@@ -592,7 +592,6 @@ class Memcached extends AbstractAdapter implements
                     'staticTtl'          => true,
                     'ttlPrecision'       => 1,
                     'useRequestTime'     => false,
-                    'expiredRead'        => false,
                     'maxKeyLength'       => 255,
                     'namespaceIsPrefix'  => true,
                 ]

--- a/src/Storage/Adapter/Memory.php
+++ b/src/Storage/Adapter/Memory.php
@@ -714,7 +714,6 @@ class Memory extends AbstractAdapter implements
                     'maxTtl'             => PHP_INT_MAX,
                     'staticTtl'          => false,
                     'ttlPrecision'       => 0.05,
-                    'expiredRead'        => true,
                     'maxKeyLength'       => 0,
                     'namespaceIsPrefix'  => false,
                     'namespaceSeparator' => '',

--- a/src/Storage/Adapter/Redis.php
+++ b/src/Storage/Adapter/Redis.php
@@ -532,7 +532,6 @@ class Redis extends AbstractAdapter implements
                     'staticTtl'          => true,
                     'ttlPrecision'       => 1,
                     'useRequestTime'     => false,
-                    'expiredRead'        => false,
                     'maxKeyLength'       => 255,
                     'namespaceIsPrefix'  => true,
                 ]

--- a/src/Storage/Adapter/WinCache.php
+++ b/src/Storage/Adapter/WinCache.php
@@ -486,7 +486,6 @@ class WinCache extends AbstractAdapter implements
                     'staticTtl'          => true,
                     'ttlPrecision'       => 1,
                     'useRequestTime'     => false,
-                    'expiredRead'        => false,
                     'namespaceIsPrefix'  => true,
                     'namespaceSeparator' => $this->getOptions()->getNamespaceSeparator(),
                 ]

--- a/src/Storage/Adapter/XCache.php
+++ b/src/Storage/Adapter/XCache.php
@@ -454,7 +454,6 @@ class XCache extends AbstractAdapter implements
                     'staticTtl'          => true,
                     'ttlPrecision'       => 1,
                     'useRequestTime'     => true,
-                    'expiredRead'        => false,
                     'maxKeyLength'       => 5182,
                     'namespaceIsPrefix'  => true,
                     'namespaceSeparator' => $this->getOptions()->getNamespaceSeparator(),

--- a/src/Storage/Capabilities.php
+++ b/src/Storage/Capabilities.php
@@ -38,16 +38,6 @@ class Capabilities
     protected $baseCapabilities;
 
     /**
-     * Expire read
-     *
-     * If it's NULL the capability isn't set and the getter
-     * returns the base capability or the default value.
-     *
-     * @var null|bool
-     */
-    protected $expiredRead;
-
-    /**
      * Max. key length
      *
      * If it's NULL the capability isn't set and the getter
@@ -403,10 +393,16 @@ class Capabilities
      * Get if expired items are readable
      *
      * @return bool
+     * @deprecated This capability has been deprecated and will be removed in the future.
+     *             Please use getStaticTtl() instead
      */
     public function getExpiredRead()
     {
-        return $this->getCapability('expiredRead', false);
+        trigger_error(
+            'This capability has been deprecated and will be removed in the future. Please use static_ttl instead',
+            E_USER_DEPRECATED
+        );
+        return !$this->getCapability('staticTtl', true);
     }
 
     /**
@@ -415,10 +411,16 @@ class Capabilities
      * @param  stdClass $marker
      * @param  bool $flag
      * @return Capabilities Fluent interface
+     * @deprecated This capability has been deprecated and will be removed in the future.
+     *             Please use setStaticTtl() instead
      */
     public function setExpiredRead(stdClass $marker, $flag)
     {
-        return $this->setCapability($marker, 'expiredRead', (bool) $flag);
+        trigger_error(
+            'This capability has been deprecated and will be removed in the future. Please use static_ttl instead',
+            E_USER_DEPRECATED
+        );
+        return $this->setCapability($marker, 'staticTtl', !!$flag);
     }
 
     /**

--- a/test/Storage/Adapter/CommonAdapterTest.php
+++ b/test/Storage/Adapter/CommonAdapterTest.php
@@ -210,8 +210,6 @@ abstract class CommonAdapterTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInternalType('numeric', $capabilities->getTtlPrecision());
         $this->assertGreaterThan(0, $capabilities->getTtlPrecision());
-
-        $this->assertInternalType('bool', $capabilities->getExpiredRead());
     }
 
     public function testKeyCapabilities()
@@ -597,7 +595,7 @@ abstract class CommonAdapterTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($this->_storage->getItem('key'));
 
         $this->_options->setTtl(0);
-        if ($capabilities->getExpiredRead()) {
+        if (!$capabilities->getStaticTtl()) {
             $this->assertEquals('value', $this->_storage->getItem('key'));
         } else {
             $this->assertNull($this->_storage->getItem('key'));
@@ -642,7 +640,7 @@ abstract class CommonAdapterTest extends \PHPUnit_Framework_TestCase
         $rs = $this->_storage->getItems(array_keys($items));
         ksort($rs); // make comparable
 
-        if ($capabilities->getExpiredRead()) {
+        if (!$capabilities->getStaticTtl()) {
             // if item expiration will be done on read there is no difference
             // between the previos set items in TTL.
             // -> all items will be expired


### PR DESCRIPTION
See #81

This capability does not make sense as it was previously for informing
that items of a storage adapter can be read if the TTL will be increased
or set to infinity but this only works on storage adapters with capability
`static_ttl` and increasing the TTL on the same time means that the item
is no longer expired. So it's basically providing the same information as
`static_ttl` but from a wrong PoV.

The capability is now returning the information provided by `static_ttl`
and will trigger a `E_USER_DEPRECATED` message.