### PR TITLE
Fixed incorrect variable usage in MongoDbResourceManager

### DIFF
--- a/src/Storage/Adapter/MongoDbResourceManager.php
+++ b/src/Storage/Adapter/MongoDbResourceManager.php
@@ -117,9 +117,9 @@ class MongoDbResourceManager
     {
         $this->resources[$id]['server'] = (string)$server;
 
-        unset($this->resource[$id]['client_instance']);
-        unset($this->resource[$id]['db_instance']);
-        unset($this->resource[$id]['collection_instance']);
+        unset($this->resources[$id]['client_instance']);
+        unset($this->resources[$id]['db_instance']);
+        unset($this->resources[$id]['collection_instance']);
     }
 
     public function getServer($id)
@@ -135,9 +135,9 @@ class MongoDbResourceManager
     {
         $this->resources[$id]['connection_options'] = $connectionOptions;
 
-        unset($this->resource[$id]['client_instance']);
-        unset($this->resource[$id]['db_instance']);
-        unset($this->resource[$id]['collection_instance']);
+        unset($this->resources[$id]['client_instance']);
+        unset($this->resources[$id]['db_instance']);
+        unset($this->resources[$id]['collection_instance']);
     }
 
     public function getConnectionOptions($id)
@@ -155,9 +155,9 @@ class MongoDbResourceManager
     {
         $this->resources[$id]['driver_options'] = $driverOptions;
 
-        unset($this->resource[$id]['client_instance']);
-        unset($this->resource[$id]['db_instance']);
-        unset($this->resource[$id]['collection_instance']);
+        unset($this->resources[$id]['client_instance']);
+        unset($this->resources[$id]['db_instance']);
+        unset($this->resources[$id]['collection_instance']);
     }
 
     public function getDriverOptions($id)
@@ -173,8 +173,8 @@ class MongoDbResourceManager
     {
         $this->resources[$id]['db'] = (string)$database;
 
-        unset($this->resource[$id]['db_instance']);
-        unset($this->resource[$id]['collection_instance']);
+        unset($this->resources[$id]['db_instance']);
+        unset($this->resources[$id]['collection_instance']);
     }
 
     public function getDatabase($id)
@@ -190,7 +190,7 @@ class MongoDbResourceManager
     {
         $this->resources[$id]['collection'] = (string)$collection;
 
-        unset($this->resource[$id]['collection_instance']);
+        unset($this->resources[$id]['collection_instance']);
     }
 
     public function getCollection($id)

--- a/test/Storage/Adapter/MongoDbResourceManagerTest.php
+++ b/test/Storage/Adapter/MongoDbResourceManagerTest.php
@@ -146,4 +146,47 @@ class MongoDbResourceManagerTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('Zend\Cache\Exception\RuntimeException');
         $this->object->getResource($id);
     }
+
+    public function testSetOptionsClearsCollectionInstance()
+    {
+        $id                = 'foo';
+        $server            = getenv('TESTS_ZEND_CACHE_MONGODB_CONNECTSTRING');
+        $connectionOptions = ['connectTimeoutMS' => 500];
+        $database          = getenv('TESTS_ZEND_CACHE_MONGODB_DATABASE');
+        $collection        = getenv('TESTS_ZEND_CACHE_MONGODB_COLLECTION');
+
+        $collectionClearingCallbacks = [
+            function () use ($id, $collection) {
+                $this->object->setCollection($id, $collection);
+            },
+            function () use ($id, $connectionOptions) {
+                $this->object->setConnectionOptions($id, $connectionOptions);
+            },
+            function () use ($id, $server) {
+                $this->object->setServer($id, $server);
+            },
+            function () use ($id) {
+                $this->object->setDriverOptions($id, []);
+            },
+            function () use ($id, $database) {
+                $this->object->setDatabase($id, $database);
+            },
+        ];
+
+        // Initialize the resource manager
+        array_walk($collectionClearingCallbacks, function (callable  $callback) {
+            $callback();
+        });
+
+        $lastCollection = $this->object->getResource($id);
+
+        // Update options on the manager and check collection instances
+        foreach ($collectionClearingCallbacks as $callback) {
+            $callback();
+            $currentCollection = $this->object->getResource($id);
+
+            $this->assertNotSame($lastCollection, $currentCollection);
+            $lastCollection = $currentCollection;
+        }
+    }
 }


### PR DESCRIPTION
Updated incorrect `$this->resource` variable usages to `$this->resources` in MongoDbResourceManager.