### PR TITLE
Use MongoDB instead of legacy mongo

### DIFF
--- a/src/Storage/Adapter/MongoDb.php
+++ b/src/Storage/Adapter/MongoDb.php
@@ -261,7 +261,7 @@ class MongoDb extends AbstractAdapter implements FlushableInterface
      */
     private function fetchFromCollection(& $normalizedKey)
     {
-		try {
+	try {
             return $this->getMongoDbResource()->findOne(['key' => $this->namespacePrefix . $normalizedKey]);
         } catch (MongoResourceException $e) {
             throw new Exception\RuntimeException($e->getMessage(), $e->getCode(), $e);

--- a/src/Storage/Adapter/MongoDb.php
+++ b/src/Storage/Adapter/MongoDb.php
@@ -2,16 +2,17 @@
 /**
  * Zend Framework (http://framework.zend.com/)
  *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @link      http://github.com/zendframework/zf3 for the canonical source repository
  * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
 namespace Zend\Cache\Storage\Adapter;
 
-use MongoCollection as MongoResource;
-use MongoDate;
-use MongoException as MongoResourceException;
+use MongoDB\Client as MongoClient;
+use MongoDB\Collection as MongoResource;
+use MongoDB\BSON\UTCDateTime as MongoDate;
+use MongoDB\Driver\Exception\Exception as MongoResourceException;
 use stdClass;
 use Zend\Cache\Exception;
 use Zend\Cache\Storage\Capabilities;
@@ -54,9 +55,9 @@ class MongoDb extends AbstractAdapter implements FlushableInterface
      */
     public function __construct($options = null)
     {
-        if (! class_exists('Mongo') || ! class_exists('MongoClient')) {
+		if (! class_exists('MongoDB\Client')) {
             throw new Exception\ExtensionNotLoadedException(
-                'MongoDb extension not loaded or Mongo polyfill not included'
+                'MongoDb extension not loaded.'
             );
         }
 
@@ -136,7 +137,7 @@ class MongoDb extends AbstractAdapter implements FlushableInterface
                 ));
             }
 
-            if ($result['expires']->sec < time()) {
+            if ($result['expires']->toDateTime() < (new \DateTime())) {
                 $this->internalRemoveItem($normalizedKey);
                 return;
             }
@@ -170,22 +171,20 @@ class MongoDb extends AbstractAdapter implements FlushableInterface
             'key' => $key,
             'value' => $value,
         ];
-
         if ($ttl > 0) {
-            $expiresMicro         = microtime(true) + $ttl;
-            $expiresSecs          = (int) $expiresMicro;
-            $cacheItem['expires'] = new MongoDate($expiresSecs, $expiresMicro - $expiresSecs);
+			$d = new \DateTime();
+			$d->add(new \DateInterval('PT' . $ttl . 'S'));
+            $cacheItem['expires'] = new MongoDate($d);
         }
 
         try {
-            $mongo->remove(['key' => $key]);
-
-            $result = $mongo->insert($cacheItem);
+			$mongo->deleteOne(['key' => $key]);
+            $result = $mongo->insertOne($cacheItem);
         } catch (MongoResourceException $e) {
             throw new Exception\RuntimeException($e->getMessage(), $e->getCode(), $e);
         }
 
-        return null !== $result && ((double) 1) === $result['ok'];
+        return null !== $result && $result->isAcknowledged();
     }
 
     /**
@@ -196,14 +195,12 @@ class MongoDb extends AbstractAdapter implements FlushableInterface
     protected function internalRemoveItem(& $normalizedKey)
     {
         try {
-            $result = $this->getMongoDbResource()->remove(['key' => $this->namespacePrefix . $normalizedKey]);
+            $result = $this->getMongoDbResource()->deleteOne(['key' => $this->namespacePrefix . $normalizedKey]);
         } catch (MongoResourceException $e) {
             throw new Exception\RuntimeException($e->getMessage(), $e->getCode(), $e);
         }
 
-        return false !== $result
-            && ((double) 1) === $result['ok']
-            && $result['n'] > 0;
+        return null !== $result && ($result->getDeletedCount() > 0);
     }
 
     /**
@@ -212,8 +209,7 @@ class MongoDb extends AbstractAdapter implements FlushableInterface
     public function flush()
     {
         $result = $this->getMongoDbResource()->drop();
-
-        return ((double) 1) === $result['ok'];
+        return ((float) 1) === $result['ok'];
     }
 
     /**
@@ -258,7 +254,6 @@ class MongoDb extends AbstractAdapter implements FlushableInterface
     protected function internalGetMetadata(& $normalizedKey)
     {
         $result = $this->fetchFromCollection($normalizedKey);
-
         return null !== $result ? ['_id' => $result['_id']] : false;
     }
 
@@ -273,7 +268,7 @@ class MongoDb extends AbstractAdapter implements FlushableInterface
      */
     private function fetchFromCollection(& $normalizedKey)
     {
-        try {
+		try {
             return $this->getMongoDbResource()->findOne(['key' => $this->namespacePrefix . $normalizedKey]);
         } catch (MongoResourceException $e) {
             throw new Exception\RuntimeException($e->getMessage(), $e->getCode(), $e);

--- a/src/Storage/Adapter/MongoDb.php
+++ b/src/Storage/Adapter/MongoDb.php
@@ -2,7 +2,7 @@
 /**
  * Zend Framework (http://framework.zend.com/)
  *
- * @link      http://github.com/zendframework/zf3 for the canonical source repository
+ * @link      https://github.com/zendframework/zend-cache for the canonical source repository
  * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */

--- a/src/Storage/Adapter/MongoDbOptions.php
+++ b/src/Storage/Adapter/MongoDbOptions.php
@@ -2,7 +2,7 @@
 /**
  * Zend Framework (http://framework.zend.com/)
  *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @link      https://github.com/zendframework/zend-cache for the canonical source repository
  * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */

--- a/src/Storage/Adapter/MongoDbResourceManager.php
+++ b/src/Storage/Adapter/MongoDbResourceManager.php
@@ -2,7 +2,7 @@
 /**
  * Zend Framework (http://framework.zend.com/)
  *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @link      https://github.com/zendframework/zend-cache for the canonical source repository
  * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */

--- a/src/Storage/Adapter/MongoDbResourceManager.php
+++ b/src/Storage/Adapter/MongoDbResourceManager.php
@@ -9,8 +9,9 @@
 
 namespace Zend\Cache\Storage\Adapter;
 
-use MongoCollection;
-use MongoException;
+use MongoDB\Client as MongoClient;
+use MongoDB\Collection as MongoCollection;
+use MongoDB\Driver\Exception\Exception as MongoException;
 use Zend\Cache\Exception;
 
 class MongoDbResourceManager
@@ -86,23 +87,22 @@ class MongoDbResourceManager
             try {
                 if (! isset($resource['db_instance'])) {
                     if (! isset($resource['client_instance'])) {
-                        $clientClass = version_compare(phpversion('mongo'), '1.3.0', '<') ? 'Mongo' : 'MongoClient';
-                        $resource['client_instance'] = new $clientClass(
+                        $resource['client_instance'] = new MongoClient(
                             isset($resource['server']) ? $resource['server'] : null,
                             isset($resource['connection_options']) ? $resource['connection_options'] : [],
                             isset($resource['driver_options']) ? $resource['driver_options'] : []
                         );
                     }
-
+/*
                     $resource['db_instance'] = $resource['client_instance']->selectDB(
                         isset($resource['db']) ? $resource['db'] : ''
                     );
-                }
-
-                $collection = $resource['db_instance']->selectCollection(
-                    isset($resource['collection']) ? $resource['collection'] : ''
+*/                }
+                $collection = $resource['client_instance']->selectCollection(
+                    isset($resource['db']) ? $resource['db'] : 'zend',
+					isset($resource['collection']) ? $resource['collection'] : 'cache'
                 );
-                $collection->ensureIndex(['key' => 1]);
+				$collection->createIndex(['key' => 1]);
 
                 $this->resources[$id]['collection_instance'] = $collection;
             } catch (MongoException $e) {

--- a/src/Storage/Adapter/MongoDbResourceManager.php
+++ b/src/Storage/Adapter/MongoDbResourceManager.php
@@ -93,16 +93,12 @@ class MongoDbResourceManager
                             isset($resource['driver_options']) ? $resource['driver_options'] : []
                         );
                     }
-/*
-                    $resource['db_instance'] = $resource['client_instance']->selectDB(
-                        isset($resource['db']) ? $resource['db'] : ''
-                    );
-*/                }
+                }
                 $collection = $resource['client_instance']->selectCollection(
                     isset($resource['db']) ? $resource['db'] : 'zend',
-					isset($resource['collection']) ? $resource['collection'] : 'cache'
+                    isset($resource['collection']) ? $resource['collection'] : 'cache'
                 );
-				$collection->createIndex(['key' => 1]);
+		$collection->createIndex(['key' => 1]);
 
                 $this->resources[$id]['collection_instance'] = $collection;
             } catch (MongoException $e) {

--- a/test/Storage/Adapter/MongoDbOptionsTest.php
+++ b/test/Storage/Adapter/MongoDbOptionsTest.php
@@ -2,7 +2,7 @@
 /**
  * Zend Framework (http://framework.zend.com/)
  *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @link      https://github.com/zendframework/zend-cache for the canonical source repository
  * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */

--- a/test/Storage/Adapter/MongoDbOptionsTest.php
+++ b/test/Storage/Adapter/MongoDbOptionsTest.php
@@ -26,7 +26,7 @@ class MongoDbOptionsTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('Enable TESTS_ZEND_CACHE_MONGODB_ENABLED to run this test');
         }
 
-        if (! extension_loaded('mongo') || ! class_exists('\Mongo') || ! class_exists('\MongoClient')) {
+        if (! class_exists('MongoDB\Client')) {
             // Allow tests to run if Mongo extension is loaded, or we have a polyfill in place
             $this->markTestSkipped("Mongo extension is not loaded");
         }

--- a/test/Storage/Adapter/MongoDbResourceManagerTest.php
+++ b/test/Storage/Adapter/MongoDbResourceManagerTest.php
@@ -2,7 +2,7 @@
 /**
  * Zend Framework (http://framework.zend.com/)
  *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @link      https://github.com/zendframework/zend-cache for the canonical source repository
  * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */

--- a/test/Storage/Adapter/MongoDbResourceManagerTest.php
+++ b/test/Storage/Adapter/MongoDbResourceManagerTest.php
@@ -28,7 +28,7 @@ class MongoDbResourceManagerTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('Enable TESTS_ZEND_CACHE_MONGODB_ENABLED to run this test');
         }
 
-        if (! extension_loaded('mongo') || ! class_exists('\Mongo') || ! class_exists('\MongoClient')) {
+        if (! class_exists('MongoDB\Client')) {
             // Allow tests to run if Mongo extension is loaded, or we have a polyfill in place
             $this->markTestSkipped("Mongo extension is not loaded");
         }

--- a/test/Storage/Adapter/MongoDbTest.php
+++ b/test/Storage/Adapter/MongoDbTest.php
@@ -2,7 +2,7 @@
 /**
  * Zend Framework (http://framework.zend.com/)
  *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @link      https://github.com/zendframework/zend-cache for the canonical source repository
  * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */

--- a/test/Storage/Adapter/MongoDbTest.php
+++ b/test/Storage/Adapter/MongoDbTest.php
@@ -24,7 +24,7 @@ class MongoDbTest extends CommonAdapterTest
             $this->markTestSkipped('Enable TESTS_ZEND_CACHE_MONGODB_ENABLED to run this test');
         }
 
-        if (! extension_loaded('mongo') || ! class_exists('\Mongo') || ! class_exists('\MongoClient')) {
+        if (! extension_loaded('mongodb') || ! class_exists('\Mongo') || ! class_exists('\MongoClient')) {
             // Allow tests to run if Mongo extension is loaded, or we have a polyfill in place
             $this->markTestSkipped("Mongo extension is not loaded");
         }


### PR DESCRIPTION
Zend\Cache and Zend\Session uses different support for Mongo as a storage. This change use the same way for Zend\Cache and therefore both modules can be used together.

I could not tun test, it fails on missing functions in another classes (dependency on ZF2?).

Regards
Vladimir