### PR TITLE
spelling fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,7 @@ matrix:
         - APCU_PECL_VERSION="apcu-5.1.2"
         - APCU_BC_PECL_VERSION="apcu_bc-1.0.0"
 
-        # TODO: re-enable these extentions as soon as they are available and stable on php 7
+        # TODO: re-enable these extensions as soon as they are available and stable on php 7
         - TESTS_ZEND_CACHE_MEMCACHE_ENABLED=false
         - TESTS_ZEND_CACHE_MEMCACHED_ENABLED=false
         - TESTS_ZEND_CACHE_MONGODB_ENABLED=false
@@ -92,7 +92,7 @@ matrix:
         - APCU_PECL_VERSION="apcu-5.1.3"
         - APCU_BC_PECL_VERSION="apcu_bc-1.0.2"
 
-        # TODO: re-enable these extentions as soon as they are available and stable on php 7
+        # TODO: re-enable these extensions as soon as they are available and stable on php 7
         - TESTS_ZEND_CACHE_MEMCACHE_ENABLED=false
         - TESTS_ZEND_CACHE_MEMCACHED_ENABLED=false
         - TESTS_ZEND_CACHE_MONGODB_ENABLED=false
@@ -103,7 +103,7 @@ matrix:
         - APCU_PECL_VERSION="apcu"            # PECL will download the latest stable version available
         - APCU_BC_PECL_VERSION="apcu_bc-beta" # TODO: change this as soon there is a stable version available
 
-        # TODO: re-enable these extentions as soon as they are available and stable on php 7
+        # TODO: re-enable these extensions as soon as they are available and stable on php 7
         - TESTS_ZEND_CACHE_MEMCACHE_ENABLED=false
         - TESTS_ZEND_CACHE_MEMCACHED_ENABLED=false
         - TESTS_ZEND_CACHE_MONGODB_ENABLED=false

--- a/doc/book/storage/capabilities.md
+++ b/doc/book/storage/capabilities.md
@@ -187,7 +187,7 @@ class Capabilities
     public function setExpiredRead(stdClass $marker, $flag);
 
     /**
-     * Get maximum key lenth
+     * Get maximum key length
      *
      * @return int -1 means unknown, 0 means infinite
      */

--- a/src/Storage/Adapter/Redis.php
+++ b/src/Storage/Adapter/Redis.php
@@ -139,7 +139,7 @@ class Redis extends AbstractAdapter implements
      * Internal method to get an item.
      *
      * @param string  &$normalizedKey Key where to store data
-     * @param bool &$success       If the operation was successfull
+     * @param bool &$success       If the operation was successful
      * @param mixed   &$casToken      Token
      * @return mixed Data on success, false on key not found
      * @throws Exception\RuntimeException

--- a/src/Storage/Capabilities.php
+++ b/src/Storage/Capabilities.php
@@ -424,7 +424,7 @@ class Capabilities
     }
 
     /**
-     * Get maximum key lenth
+     * Get maximum key length
      *
      * @return int -1 means unknown, 0 means infinite
      */


### PR DESCRIPTION
patch contains some spelling fixes ( just in comments ) as found by a bot ( http://www.misfix.org, https://github.com/ka7/misspell_fixer ). Any upcoming License changes (e.g. GPL2 to GPL3+) are hereby granted.