### PR TITLE
Give php the absolute `use` path to Traversable

### DIFF
--- a/src/Storage/Adapter/AdapterOptions.php
+++ b/src/Storage/Adapter/AdapterOptions.php
@@ -10,6 +10,7 @@
 namespace Zend\Cache\Storage\Adapter;
 
 use ArrayObject;
+use Traversable;
 use Zend\Cache\Exception;
 use Zend\Cache\Storage\Event;
 use Zend\Cache\Storage\StorageInterface;


### PR DESCRIPTION
Without that use statement, the check would always be false. See https://3v4l.org/#preview
This was detected by etsy/phan, and the bug may or may not occur in real code.

This change affects setFromArray() on line 315