### PR TITLE
remove .swp file on FileSystem::internalSetItem(s)() when it exists after put content

### DIFF
--- a/src/Storage/Adapter/Filesystem.php
+++ b/src/Storage/Adapter/Filesystem.php
@@ -971,7 +971,7 @@ class Filesystem extends AbstractAdapter implements
             $this->putFileContent($filespec . '.dat', $value);
         }
 
-        if (file_exists( $dirname = dirname($filespec. '.dat') . '.swp')) {
+        if (file_exists($dirname = dirname($filespec. '.dat') . '.swp')) {
             $this->unlink($dirname . '.swp');
         }
 
@@ -1009,6 +1009,9 @@ class Filesystem extends AbstractAdapter implements
                 $this->putFileContent($file, $content, $nonBlocking, $wouldblock);
                 if (! $nonBlocking || ! $wouldblock) {
                     unset($contents[$file]);
+                }
+                if (file_exists($dirname = dirname($file) . '.swp')) {
+                    $this->unlink($dirname . '.swp');
                 }
             }
         }

--- a/src/Storage/Adapter/Filesystem.php
+++ b/src/Storage/Adapter/Filesystem.php
@@ -971,8 +971,8 @@ class Filesystem extends AbstractAdapter implements
             $this->putFileContent($filespec . '.dat', $value);
         }
 
-        if (file_exists($dirname = dirname($filespec. '.dat') . '.swp')) {
-            $this->unlink($dirname . '.swp');
+        if (file_exists($swpFile = dirname($filespec. '.dat') . DIRECTORY_SEPARATOR . '.swp')) {
+            $this->unlink($swpFile);
         }
 
         return true;
@@ -1010,8 +1010,8 @@ class Filesystem extends AbstractAdapter implements
                 if (! $nonBlocking || ! $wouldblock) {
                     unset($contents[$file]);
                 }
-                if (file_exists($dirname = dirname($file) . '.swp')) {
-                    $this->unlink($dirname . '.swp');
+                if (file_exists($swpFile = dirname($file) . DIRECTORY_SEPARATOR . '.swp')) {
+                    $this->unlink($swpFile);
                 }
             }
         }

--- a/src/Storage/Adapter/Filesystem.php
+++ b/src/Storage/Adapter/Filesystem.php
@@ -971,6 +971,10 @@ class Filesystem extends AbstractAdapter implements
             $this->putFileContent($filespec . '.dat', $value);
         }
 
+        if (file_exists( $dirname = dirname($filespec. '.dat') . '.swp')) {
+            $this->unlink($dirname . '.swp');
+        }
+
         return true;
     }
 


### PR DESCRIPTION
I use ubuntu 14.04.4 LTS and when file created, it created ".swp" file like the following: 

```
../
./
zfcache-foo.dat
.swp
```

while I tried in centos, the ".swp" file is not created during "setItem()"