### PR TITLE
Fix a bug where the Redis adapter returns an int for hasItem()

### DIFF
--- a/src/Storage/Adapter/Redis.php
+++ b/src/Storage/Adapter/Redis.php
@@ -206,7 +206,7 @@ class Redis extends AbstractAdapter implements
     {
         $redis = $this->getRedisResource();
         try {
-            return $redis->exists($this->namespacePrefix . $normalizedKey);
+            return (bool)$redis->exists($this->namespacePrefix . $normalizedKey);
         } catch (RedisResourceException $e) {
             throw new Exception\RuntimeException($redis->getLastError(), $e->getCode(), $e);
         }

--- a/test/Storage/Adapter/RedisTest.php
+++ b/test/Storage/Adapter/RedisTest.php
@@ -364,7 +364,10 @@ class RedisTest extends CommonAdapterTest
         $this->assertTrue($hasItem);
     }
 
-    private function createAdapterFromResource(RedisResource $redis): Redis
+    /**
+     * @return Redis
+     */
+    private function createAdapterFromResource(RedisResource $redis)
     {
         $resourceManager = new RedisResourceManager();
         $resourceId = 'my-resource';

--- a/test/Storage/Adapter/RedisTest.php
+++ b/test/Storage/Adapter/RedisTest.php
@@ -9,8 +9,12 @@
 
 namespace ZendTest\Cache\Storage\Adapter;
 
+use PHPUnit_Framework_MockObject_MockObject;
 use Zend\Cache;
 use Redis as RedisResource;
+use Zend\Cache\Storage\Adapter\Redis;
+use Zend\Cache\Storage\Adapter\RedisOptions;
+use Zend\Cache\Storage\Adapter\RedisResourceManager;
 
 /**
  * @covers Zend\Cache\Storage\Adapter\Redis<extended>
@@ -336,5 +340,46 @@ class RedisTest extends CommonAdapterTest
         $this->_storage->getOptions()->setTtl($ttl);
         $this->assertTrue($this->_storage->touchItem($key));
         $this->assertEquals($ttl, ceil($this->_storage->getMetadata($key)['ttl']));
+    }
+
+    public function testHasItemReturnsFalseIfRedisExistsReturnsZero()
+    {
+        $redis = $this->mockInitializedRedisResource();
+        $redis->method('exists')->willReturn(0);
+        $adapter = $this->createAdapterFromResource($redis);
+
+        $hasItem = $adapter->hasItem('does-not-exist');
+
+        $this->assertFalse($hasItem);
+    }
+
+    public function testHasItemReturnsTrueIfRedisExistsReturnsNonZeroInt()
+    {
+        $redis = $this->mockInitializedRedisResource();
+        $redis->method('exists')->willReturn(23);
+        $adapter = $this->createAdapterFromResource($redis);
+
+        $hasItem = $adapter->hasItem('does-not-exist');
+
+        $this->assertTrue($hasItem);
+    }
+
+    private function createAdapterFromResource(RedisResource $redis): Redis
+    {
+        $resourceManager = new RedisResourceManager();
+        $resourceId = 'my-resource';
+        $resourceManager->setResource($resourceId, $redis);
+        $options = new RedisOptions(['resource_manager' => $resourceManager, 'resource_id' => $resourceId]);
+        return new Redis($options);
+    }
+
+    /**
+     * @return PHPUnit_Framework_MockObject_MockObject|RedisResource
+     */
+    private function mockInitializedRedisResource()
+    {
+        $redis = $this->getMock(RedisResource::class);
+        $redis->socket = true;
+        return $redis;
     }
 }


### PR DESCRIPTION
Version 4 of the Redis extension returns an integer instead of a boolean when exists() is called. See https://github.com/phpredis/phpredis/blob/develop/README.markdown#exists