### PR TITLE
Skip tests for unsupported PSR-6 driver deferred save

### DIFF
--- a/docs/book/psr6.md
+++ b/docs/book/psr6.md
@@ -60,6 +60,9 @@ fulfil this requirement.
 
 Attempting to use an unsupported adapter will throw an exception implementing `Psr\Cache\CacheException`.
 
+The `Zend\Cache\Psr\CacheItemPoolAdapter` adapter doesn't support driver deferred saves, so cache items are saved
+on destruct or on explicit `commit()` call.
+
 ### Quirks
 
 #### APC

--- a/test/Psr/ApcIntegrationTest.php
+++ b/test/Psr/ApcIntegrationTest.php
@@ -77,6 +77,13 @@ class ApcIntegrationTest extends CachePoolTest
     {
         try {
             $storage = StorageFactory::adapterFactory('apc');
+
+            $deferredSkippedMessage = sprintf(
+                '%s storage doesn\'t support driver deferred',
+                \get_class($storage)
+            );
+            $this->skippedTests['testHasItemReturnsFalseWhenDeferredItemIsExpired'] = $deferredSkippedMessage;
+
             return new CacheItemPoolAdapter($storage);
         } catch (Exception\ExtensionNotLoadedException $e) {
             $this->markTestSkipped($e->getMessage());

--- a/test/Psr/ApcuIntegrationTest.php
+++ b/test/Psr/ApcuIntegrationTest.php
@@ -77,6 +77,13 @@ class ApcuIntegrationTest extends CachePoolTest
     {
         try {
             $storage = StorageFactory::adapterFactory('apcu');
+
+            $deferredSkippedMessage = sprintf(
+                '%s storage doesn\'t support driver deferred',
+                \get_class($storage)
+            );
+            $this->skippedTests['testHasItemReturnsFalseWhenDeferredItemIsExpired'] = $deferredSkippedMessage;
+
             return new CacheItemPoolAdapter($storage);
         } catch (Exception\ExtensionNotLoadedException $e) {
             $this->markTestSkipped($e->getMessage());

--- a/test/Psr/DbaIntegrationTest.php
+++ b/test/Psr/DbaIntegrationTest.php
@@ -26,6 +26,13 @@ class DbaIntegrationTest extends TestCase
     {
         try {
             $storage = StorageFactory::adapterFactory('dba');
+
+            $deferredSkippedMessage = sprintf(
+                '%s storage doesn\'t support driver deferred',
+                \get_class($storage)
+            );
+            $this->skippedTests['testHasItemReturnsFalseWhenDeferredItemIsExpired'] = $deferredSkippedMessage;
+
             return new CacheItemPoolAdapter($storage);
         } catch (Exception\ExtensionNotLoadedException $e) {
             $this->markTestSkipped($e->getMessage());

--- a/test/Psr/MemcacheIntegrationTest.php
+++ b/test/Psr/MemcacheIntegrationTest.php
@@ -72,6 +72,13 @@ class MemcacheIntegrationTest extends CachePoolTest
 
         try {
             $storage = StorageFactory::adapterFactory('memcache', $options);
+
+            $deferredSkippedMessage = sprintf(
+                '%s storage doesn\'t support driver deferred',
+                \get_class($storage)
+            );
+            $this->skippedTests['testHasItemReturnsFalseWhenDeferredItemIsExpired'] = $deferredSkippedMessage;
+
             return new CacheItemPoolAdapter($storage);
         } catch (Exception\ExtensionNotLoadedException $e) {
             $this->markTestSkipped($e->getMessage());

--- a/test/Psr/MemcachedIntegrationTest.php
+++ b/test/Psr/MemcachedIntegrationTest.php
@@ -72,6 +72,13 @@ class MemcachedIntegrationTest extends CachePoolTest
 
         try {
             $storage = StorageFactory::adapterFactory('memcached', $options);
+
+            $deferredSkippedMessage = sprintf(
+                '%s storage doesn\'t support driver deferred',
+                \get_class($storage)
+            );
+            $this->skippedTests['testHasItemReturnsFalseWhenDeferredItemIsExpired'] = $deferredSkippedMessage;
+
             return new CacheItemPoolAdapter($storage);
         } catch (Exception\ExtensionNotLoadedException $e) {
             $this->markTestSkipped($e->getMessage());

--- a/test/Psr/MongoDbIntegrationTest.php
+++ b/test/Psr/MongoDbIntegrationTest.php
@@ -61,6 +61,13 @@ class MongoDbIntegrationTest extends CachePoolTest
                 'database'   => getenv('TESTS_ZEND_CACHE_MONGODB_DATABASE'),
                 'collection' => getenv('TESTS_ZEND_CACHE_MONGODB_COLLECTION'),
             ]);
+
+            $deferredSkippedMessage = sprintf(
+                '%s storage doesn\'t support driver deferred',
+                \get_class($storage)
+            );
+            $this->skippedTests['testHasItemReturnsFalseWhenDeferredItemIsExpired'] = $deferredSkippedMessage;
+
             return new CacheItemPoolAdapter($storage);
         } catch (Exception\ExtensionNotLoadedException $e) {
             $this->markTestSkipped($e->getMessage());

--- a/test/Psr/RedisIntegrationTest.php
+++ b/test/Psr/RedisIntegrationTest.php
@@ -73,6 +73,13 @@ class RedisIntegrationTest extends CachePoolTest
 
         try {
             $storage = StorageFactory::adapterFactory('redis', $options);
+
+            $deferredSkippedMessage = sprintf(
+                '%s storage doesn\'t support driver deferred',
+                \get_class($storage)
+            );
+            $this->skippedTests['testHasItemReturnsFalseWhenDeferredItemIsExpired'] = $deferredSkippedMessage;
+
             return new CacheItemPoolAdapter($storage);
         } catch (Exception\ExtensionNotLoadedException $e) {
             $this->markTestSkipped($e->getMessage());

--- a/test/Psr/WinCacheIntegrationTest.php
+++ b/test/Psr/WinCacheIntegrationTest.php
@@ -60,6 +60,13 @@ class WinCacheIntegrationTest extends CachePoolTest
     {
         try {
             $storage = StorageFactory::adapterFactory('wincache');
+
+            $deferredSkippedMessage = sprintf(
+                '%s storage doesn\'t support driver deferred',
+                \get_class($storage)
+            );
+            $this->skippedTests['testHasItemReturnsFalseWhenDeferredItemIsExpired'] = $deferredSkippedMessage;
+
             return new CacheItemPoolAdapter($storage);
         } catch (Exception\ExtensionNotLoadedException $e) {
             $this->markTestSkipped($e->getMessage());

--- a/test/Psr/XCacheIntegrationTest.php
+++ b/test/Psr/XCacheIntegrationTest.php
@@ -34,6 +34,13 @@ class XCacheIntegrationTest extends TestCase
                 'admin_user' => getenv('TESTS_ZEND_CACHE_XCACHE_ADMIN_USER') ?: '',
                 'admin_pass' => getenv('TESTS_ZEND_CACHE_XCACHE_ADMIN_PASS') ?: '',
             ]);
+
+            $deferredSkippedMessage = sprintf(
+                '%s storage doesn\'t support driver deferred',
+                \get_class($storage)
+            );
+            $this->skippedTests['testHasItemReturnsFalseWhenDeferredItemIsExpired'] = $deferredSkippedMessage;
+
             return new CacheItemPoolAdapter($storage);
         } catch (Exception\ExtensionNotLoadedException $e) {
             $this->markTestSkipped($e->getMessage());

--- a/test/Psr/ZendServerDiskIntegrationTest.php
+++ b/test/Psr/ZendServerDiskIntegrationTest.php
@@ -51,6 +51,13 @@ class ZendServerDiskIntegrationTest extends CachePoolTest
     {
         try {
             $storage = StorageFactory::adapterFactory('zendserverdisk');
+
+            $deferredSkippedMessage = sprintf(
+                '%s storage doesn\'t support driver deferred',
+                \get_class($storage)
+            );
+            $this->skippedTests['testHasItemReturnsFalseWhenDeferredItemIsExpired'] = $deferredSkippedMessage;
+
             return new CacheItemPoolAdapter($storage);
         } catch (Exception\ExtensionNotLoadedException $e) {
             $this->markTestSkipped($e->getMessage());

--- a/test/Psr/ZendServerShmIntegrationTest.php
+++ b/test/Psr/ZendServerShmIntegrationTest.php
@@ -55,6 +55,13 @@ class ZendServerShmIntegrationTest extends CachePoolTest
     {
         try {
             $storage = StorageFactory::adapterFactory('zendservershm');
+
+            $deferredSkippedMessage = sprintf(
+                '%s storage doesn\'t support driver deferred',
+                \get_class($storage)
+            );
+            $this->skippedTests['testHasItemReturnsFalseWhenDeferredItemIsExpired'] = $deferredSkippedMessage;
+
             return new CacheItemPoolAdapter($storage);
         } catch (Exception\ExtensionNotLoadedException $e) {
             $this->markTestSkipped($e->getMessage());


### PR DESCRIPTION
The `Zend\Cache\Psr\CacheItemPoolAdapter` adapter doesn't support driver deferred saves, so cache items are saved on destruct or on explicit `commit()` call.

Tests should be skipped.

Please check what I wrote, my english is not good enough.