### PR TITLE
Provide a PSR-16 decorator for zend-cache storage adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
+- [#148](https://github.com/zendframework/zend-cache/pull/148) adds support for PHP 7.1 and 7.2.
+
+- [#152](https://github.com/zendframework/zend-cache/pull/152) adds an adapter providing [PSR-16](https://www.php-fig.org/psr/psr-16/) (Caching Library Interface) support.
+  The new class, `Zend\Cache\Psr\SimpleCacheDecorator`, accepts a
+  `Zend\Cache\Storage\StorageInterface` instance to its constructor, and proxies
+  the various PSR-16 methods to it.
+
+- [#46](https://github.com/zendframework/zend-cache/issues/46) adds support for [PSR-6](https://www.php-fig.org/psr/psr-6/) (Caching Interface).
+  It provides an implementation of `Psr\Cache\CacheItemPoolInterface` via
+  `Zend\Cache\Psr\CacheItemPoolAdapter`, which accepts a
+  `Zend\Cache\Storage\StorageInterface` instance to its constructor, and proxies
+  the various PSR-6 methods to it. It also provides a
+  `Psr\Cache\CacheItemInterface` implementation via `Zend\Cache\Psr\CacheItem`,
+  which provides a value object for both introspecting cache fetch results, as
+  well as providing values to cache.
+
 - [#154](https://github.com/zendframework/zend-cache/pull/154) adds an ext-mongodb adapter, `Zend\Cache\Storage\Adapter\ExtMongoDb`.
   You may use the `StorageFactory` to create an instance using either the fully qualified class
   name as the adapter name, or the strings `ext_mongo_db` or `ExtMongoDB` (or most variations
@@ -13,29 +29,24 @@ All notable changes to this project will be documented in this file, in reverse 
   `Zend\Cache\Storage\Adapter\MongoDb`, and it provides the same capabilities. The adapter
   requires the mongodb/mongodb package to operate.
 
-- [#148](https://github.com/zendframework/zend-cache/pull/148) adds support for PHP 7.1 and 7.2.
-
 - [#120](https://github.com/zendframework/zend-cache/pull/120) adds the ability to configure alternate file suffixes for both
   cache and tag cache files within the Filesystem adapter. Use the `suffix` and `tag_suffix`
   options to set them; they will default to `dat` and `tag`, respectively.
 
-- [#116](https://github.com/zendframework/zend-cache/pull/116)
-  docblock method chaining consistency
-- [#46](https://github.com/zendframework/zend-cache/issues/46)
-  Add wrapper for PSR-6
 - [#79](https://github.com/zendframework/zend-cache/issues/79)
   Add capability for the "lock-on-expire" feature (úsed by Zend Data Cache)
 
 ### Changed
 
-- Nothing.
+- [#116](https://github.com/zendframework/zend-cache/pull/116) adds docblock method chaining consistency.
 
 ### Deprecated
 
-- [#101](https://github.com/zendframework/zend-cache/pull/101)
-  bump minimum php version to 5.6, as 5.5 goes EOL
+- Nothing.
 
 ### Removed
+
+- [#101](https://github.com/zendframework/zend-cache/pull/101) removes support for PHP 5.5.
 
 - [#148](https://github.com/zendframework/zend-cache/pull/148) removes support for HHVM.
 
@@ -49,8 +60,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 - [#150](https://github.com/zendframework/zend-cache/pull/150) fixes an issue with how CAS tokens are handled when using the memcached adapter.
 
-- [#61](https://github.com/zendframework/zend-cache/pull/61)
-  Zend Data Cache: minTtl => 1
+- [#61](https://github.com/zendframework/zend-cache/pull/61) sets the Zend Data Cache minTtl value to 1.
 
 ## 2.7.3 - TBD
 

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "psr/cache": "^1.0",
+        "psr/simple-cache": "^1.0",
         "zendframework/zend-eventmanager": "^2.6.3 || ^3.2",
         "zendframework/zend-servicemanager": "^2.7.8 || ^3.3",
         "zendframework/zend-stdlib": "^2.7.7 || ^3.1"

--- a/composer.json
+++ b/composer.json
@@ -67,6 +67,10 @@
     "config": {
         "sort-packages": true
     },
+    "provide": {
+        "psr/cache-implementation": "1.0",
+        "psr/simple-cache-implementation": "1.0"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "2.7.x-dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "be098d87fe46d1f3a9f3532652e8c55a",
+    "content-hash": "58b4fcf08ede61109e98e78e56b866bd",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -131,6 +131,54 @@
                 "psr"
             ],
             "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
+            "name": "psr/simple-cache",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "time": "2017-10-23T01:57:42+00:00"
         },
         {
             "name": "zendframework/zend-eventmanager",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "58b4fcf08ede61109e98e78e56b866bd",
+    "content-hash": "9fa7082ad17f5261baa8e6f4ae3ff89d",
     "packages": [
         {
             "name": "container-interop/container-interop",

--- a/docs/book/psr16.md
+++ b/docs/book/psr16.md
@@ -1,0 +1,66 @@
+# PSR-16 Support
+
+- Since 2.8.0
+
+[PSR-16](https://www.php-fig.org/psr/psr-16/) provides a simplified approach to
+cache access that does not involve cache pools, tags, deferment, etc.; it
+can be thought of as a key/value storage approach to caching.
+
+zend-cache provides PSR-16 support via the class
+`Zend\Cache\Psr\SimpleCacheDecorator`. This class implements PSR-16's
+`Psr\SimpleCache\CacheInterface`, and composes a
+`Zend\Cache\Storage\StorageInterface` instance to which it proxies all
+operations.
+
+Instantiation is as follows:
+
+```php
+use Zend\Cache\StorageFactory;
+use Zend\Cache\Psr\SimpleCacheDecorator;
+
+$storage = StorageFactory::factory([
+    'adapter' => [
+        'name'    => 'apc',
+        'options' => [],
+    ],
+]);
+
+$cache = new SimpleCacheDecorator($storage);
+```
+
+Once you have a `SimpleCacheDecorator` instance, you can perform operations per
+that specification:
+
+```php
+// Use has() to determine whether to fetch the value or calculate it:
+$value = $cache->has('someKey') ? $cache->get('someKey') : calculateValue();
+if (! $cache->has('someKey')) {
+    $cache->set('someKey', $value);
+}
+
+// Or use a default value:
+$value = $cache->get('someKey', $defaultValue);
+```
+
+When setting values, whether single values or multiple, you can also optionally
+provide a Time To Live (TTL) value. This proxies to the underlying storage
+instance's options, temporarily resetting its TTL value for the duration of the
+operation. TTL values may be expressed as integers (in which case they represent
+seconds) or `DateInterval` instances. As examples:
+
+```php
+$cache->set('someKey', $value, 30); // set TTL to 30s
+$cache->set('someKey', $value, new DateInterval('P1D'); // set TTL to 1 day
+
+$cache->setMultiple([
+    'key1' => $value1,
+    'key2' => $value2,
+], 3600); // set TTL to 1 hour
+$cache->setMultiple([
+    'key1' => $value1,
+    'key2' => $value2,
+], new DateInterval('P6H'); // set TTL to 6 hours
+```
+
+For more details on what methods are exposed, consult the [CacheInterface
+specification](https://www.php-fig.org/psr/psr-16/#21-cacheinterface).

--- a/docs/book/psr6.md
+++ b/docs/book/psr6.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The `Zend\Cache\Psr\CacheItemPoolAdapter` provides a [PSR-6](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-6-cache.md)
+The `Zend\Cache\Psr\CacheItemPoolAdapter` provides a [PSR-6](https://www.php-fig.org/psr/psr-6/)
 compliant wrapper for supported storage adapters.
 
 PSR-6 specifies a common interface to cache storage, enabling developers to switch between implementations without

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,7 @@ pages:
         - OutputCache: pattern/output-cache.md
         - CaptureCache: pattern/capture-cache.md
     - PSR-6: psr6.md
+    - PSR-16: psr16.md
 site_name: zend-cache
 site_description: Zend\Cache
 repo_url: 'https://github.com/zendframework/zend-cache'

--- a/src/Psr/SerializationTrait.php
+++ b/src/Psr/SerializationTrait.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-cache/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Cache\Psr;
+
+use Zend\Cache\Storage\StorageInterface;
+
+/**
+ * Provides common functionality surrounding value de/serialization as required
+ * by both PSR-6 and PSR-16
+ */
+trait SerializationTrait
+{
+    /**
+     * @var bool
+     */
+    private $serializeValues = false;
+
+    /**
+     * @var string
+     */
+    private static $serializedFalse;
+
+    /**
+     * Determine if the given storage adapter requires serialization.
+     *
+     * Determines if the given storage adapter requires serialization. If so,
+     * set $serializeValues to true, and serialize a boolean false for later
+     * comparisons.
+     *
+     * @param StorageInterface $storage
+     * @return void
+     */
+    private function memoizeSerializationCapabilities(StorageInterface $storage)
+    {
+        $capabilities = $storage->getCapabilities();
+        $requiredTypes = ['string', 'integer', 'double', 'boolean', 'NULL', 'array', 'object'];
+        $types = $capabilities->getSupportedDatatypes();
+        $shouldSerialize = false;
+
+        foreach ($requiredTypes as $type) {
+            // 'object' => 'object' is OK
+            // 'integer' => 'string' is not (redis)
+            // 'integer' => 'integer' is not (memcache)
+            if (! (isset($types[$type]) && in_array($types[$type], [true, 'array', 'object'], true))) {
+                $shouldSerialize = true;
+                break;
+            }
+        }
+
+        if ($shouldSerialize) {
+            static::$serializedFalse = serialize(false);
+        }
+
+        $this->serializeValues = $shouldSerialize;
+    }
+
+    /**
+     * Unserialize a value retrieved from the cache.
+     *
+     * @param string $value
+     * @return mixed
+     */
+    abstract public function unserialize($value);
+}

--- a/src/Psr/SimpleCacheDecorator.php
+++ b/src/Psr/SimpleCacheDecorator.php
@@ -7,9 +7,13 @@
 
 namespace Zend\Cache\Psr;
 
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeZone;
 use Exception;
 use Psr\SimpleCache\CacheInterface as SimpleCacheInterface;
 use Throwable;
+use Traversable;
 use Zend\Cache\Exception\InvalidArgumentException as ZendCacheInvalidArgumentException;
 use Zend\Cache\Storage\FlushableInterface;
 use Zend\Cache\Storage\StorageInterface;
@@ -24,7 +28,7 @@ class SimpleCacheDecorator implements SimpleCacheInterface
     /**
      * Characters reserved by PSR-16 that are not valid in cache keys.
      */
-    const INVALID_KEY_CHARS = '@{}()/\\';
+    const INVALID_KEY_CHARS = ':@{}()/\\';
 
     /**
      * @var bool
@@ -44,11 +48,17 @@ class SimpleCacheDecorator implements SimpleCacheInterface
      */
     private $success;
 
+    /**
+     * @var DateTimeZone
+     */
+    private $utc;
+
     public function __construct(StorageInterface $storage)
     {
         $this->memoizeSerializationCapabilities($storage);
         $this->memoizeTtlCapabilities($storage);
         $this->storage = $storage;
+        $this->utc = new DateTimeZone('UTC');
     }
 
     /**
@@ -56,6 +66,8 @@ class SimpleCacheDecorator implements SimpleCacheInterface
      */
     public function get($key, $default = null)
     {
+        $this->validateKey($key);
+
         $this->success = null;
         try {
             $result = $this->storage->getItem($key, $this->success);
@@ -80,10 +92,10 @@ class SimpleCacheDecorator implements SimpleCacheInterface
     public function set($key, $value, $ttl = null)
     {
         $this->validateKey($key);
+        $ttl = $this->convertTtlToInteger($ttl);
 
         // PSR-16 states that 0 or negative TTL values should result in cache
         // invalidation for the item.
-        $ttl = null !== $ttl ? (int) $ttl : null;
         if (null !== $ttl && 1 > $ttl) {
             return $this->delete($key);
         }
@@ -116,6 +128,12 @@ class SimpleCacheDecorator implements SimpleCacheInterface
      */
     public function delete($key)
     {
+        $this->validateKey($key);
+
+        if (! $this->storage->hasItem($key)) {
+            return true;
+        }
+
         try {
             return $this->storage->removeItem($key);
         } catch (Throwable $e) {
@@ -141,6 +159,9 @@ class SimpleCacheDecorator implements SimpleCacheInterface
      */
     public function getMultiple($keys, $default = null)
     {
+        $keys = $this->convertIterableToArray($keys, false, __FUNCTION__);
+        array_walk($keys, [$this, 'validateKey']);
+
         try {
             $results = $this->storage->getItems($keys);
         } catch (Throwable $e) {
@@ -150,7 +171,7 @@ class SimpleCacheDecorator implements SimpleCacheInterface
         }
 
         foreach ($keys as $key) {
-            if (! isset($results[$key]) && null !== $default) {
+            if (! isset($results[$key])) {
                 $results[$key] = $default;
                 continue;
             }
@@ -170,7 +191,8 @@ class SimpleCacheDecorator implements SimpleCacheInterface
      */
     public function setMultiple($values, $ttl = null)
     {
-        $ttl = null !== $ttl ? (int) $ttl : null;
+        $values = $this->convertIterableToArray($values, true, __FUNCTION__);
+        $ttl = $this->convertTtlToInteger($ttl);
 
         foreach (array_keys($values) as $key) {
             $this->validateKey($key);
@@ -205,7 +227,18 @@ class SimpleCacheDecorator implements SimpleCacheInterface
         }
 
         $options->setTtl($previousTtl);
-        return $result;
+
+        if (empty($result)) {
+            return true;
+        }
+
+        foreach ($result as $index => $key) {
+            if (! $this->storage->hasItem($key)) {
+                unset($result[$index]);
+            }
+        }
+
+        return empty($result);
     }
 
     /**
@@ -213,14 +246,32 @@ class SimpleCacheDecorator implements SimpleCacheInterface
      */
     public function deleteMultiple($keys)
     {
+        $keys = $this->convertIterableToArray($keys, false, __FUNCTION__);
+        if (empty($keys)) {
+            return true;
+        }
+
+        array_walk($keys, [$this, 'validateKey']);
+
         try {
             $result = $this->storage->removeItems($keys);
-            return empty($result);
         } catch (Throwable $e) {
             throw static::translateException($e);
         } catch (Exception $e) {
             throw static::translateException($e);
         }
+
+        if (empty($result)) {
+            return true;
+        }
+
+        foreach ($result as $index => $key) {
+            if (! $this->storage->hasItem($key)) {
+                unset($result[$index]);
+            }
+        }
+
+        return empty($result);
     }
 
     /**
@@ -228,6 +279,8 @@ class SimpleCacheDecorator implements SimpleCacheInterface
      */
     public function has($key)
     {
+        $this->validateKey($key);
+
         try {
             return $this->storage->hasItem($key);
         } catch (Throwable $e) {
@@ -257,6 +310,30 @@ class SimpleCacheDecorator implements SimpleCacheInterface
      */
     private function validateKey($key)
     {
+        if ('' === $key) {
+            throw new SimpleCacheInvalidArgumentException(
+                'Invalid key provided; cannot be empty'
+            );
+        }
+
+        if (0 === $key) {
+            // cache/integration-tests erroneously tests that ['0' => 'value']
+            // is a valid payload to setMultiple(). However, PHP silently
+            // converts '0' to 0, which would normally be invalid. For now,
+            // we need to catch just this single value so tests pass.
+            // I have filed an issue to correct the test:
+            // https://github.com/php-cache/integration-tests/issues/92
+            return $key;
+        }
+
+        if (! is_string($key)) {
+            throw new SimpleCacheInvalidArgumentException(sprintf(
+                'Invalid key provided of type "%s"%s; must be a string',
+                is_object($key) ? get_class($key) : gettype($key),
+                is_scalar($key) ? sprintf(' (%s)', var_export($key, true)) : ''
+            ));
+        }
+
         $regex = sprintf('/[%s]/', preg_quote(self::INVALID_KEY_CHARS, '/'));
         if (preg_match($regex, $key)) {
             throw new SimpleCacheInvalidArgumentException(sprintf(
@@ -310,5 +387,86 @@ class SimpleCacheDecorator implements SimpleCacheInterface
     {
         $capabilities = $storage->getCapabilities();
         $this->providesPerItemTtl = $capabilities->getStaticTtl() && (0 < $capabilities->getMinTtl());
+    }
+
+    /**
+     * @param int|DateInterval
+     * @return null|int
+     * @throws SimpleCacheInvalidArgumentException for invalid arguments
+     */
+    private function convertTtlToInteger($ttl)
+    {
+        // null === absence of a TTL
+        if (null === $ttl) {
+            return null;
+        }
+
+        // integers are always okay
+        if (is_int($ttl)) {
+            return $ttl;
+        }
+
+        // Numeric strings evaluating to integers can be cast
+        if (is_string($ttl)
+            && ('0' === $ttl
+                || preg_match('/^[1-9][0-9]+$/', $ttl)
+            )
+        ) {
+            return (int) $ttl;
+        }
+
+        // DateIntervals require conversion
+        if ($ttl instanceof DateInterval) {
+            $now = new DateTimeImmutable('now', $this->utc);
+            $end = $now->add($ttl);
+            return $end->getTimestamp() - $now->getTimestamp();
+        }
+
+        // All others are invalid
+        throw new SimpleCacheInvalidArgumentException(sprintf(
+            'Invalid TTL "%s" provided; must be null, an integer, or a %s instance',
+            is_object($ttl) ? get_class($ttl) : var_export($ttl, true),
+            DateInterval::class
+        ));
+    }
+
+    /**
+     * @param array|iterable $iterable
+     * @param bool $useKeys Whether or not to preserve keys during conversion
+     * @param string $forMethod Method that called this one; used for reporting
+     *     invalid values.
+     * @return array
+     * @throws SimpleCacheInvalidArgumentException for invalid $iterable values
+     */
+    private function convertIterableToArray($iterable, $useKeys, $forMethod)
+    {
+        if (is_array($iterable)) {
+            return $iterable;
+        }
+
+        if (! $iterable instanceof Traversable) {
+            throw new SimpleCacheInvalidArgumentException(sprintf(
+                'Invalid value provided to %s::%s; must be an array or Traversable',
+                __CLASS__,
+                $forMethod
+            ));
+        }
+
+        $array = [];
+        foreach ($iterable as $key => $value) {
+            if (! $useKeys) {
+                $array[] = $value;
+                continue;
+            }
+
+            if (! is_string($key) && ! is_int($key) && ! is_float($key)) {
+                throw new SimpleCacheInvalidArgumentException(sprintf(
+                    'Invalid key detected of type "%s"; must be a scalar',
+                    is_object($key) ? get_class($key) : gettype($key)
+                ));
+            }
+            $array[$key] = $value;
+        }
+        return $array;
     }
 }

--- a/src/Psr/SimpleCacheDecorator.php
+++ b/src/Psr/SimpleCacheDecorator.php
@@ -222,7 +222,7 @@ class SimpleCacheDecorator implements SimpleCacheInterface
         $regex = sprintf('/[%s]/', preg_quote(self::INVALID_KEY_CHARS, '/'));
         if (preg_match($regex, $key)) {
             throw new SimpleCacheInvalidArgumentException(sprintf(
-                'Invalid key "%s" provided; cannot contain any of ()',
+                'Invalid key "%s" provided; cannot contain any of (%s)',
                 $key,
                 self::INVALID_KEY_CHARS
             ));

--- a/src/Psr/SimpleCacheDecorator.php
+++ b/src/Psr/SimpleCacheDecorator.php
@@ -209,5 +209,12 @@ class SimpleCacheDecorator implements SimpleCacheInterface
                 self::INVALID_KEY_CHARS
             ));
         }
+
+        if (preg_match('/^.{65,}/u', $key)) {
+            throw new SimpleCacheInvalidArgumentException(sprintf(
+                'Invalid key "%s" provided; key is too long. Must be no more than 64 characters',
+                $key
+            ));
+        }
     }
 }

--- a/src/Psr/SimpleCacheDecorator.php
+++ b/src/Psr/SimpleCacheDecorator.php
@@ -117,9 +117,9 @@ class SimpleCacheDecorator implements SimpleCacheInterface
             throw static::translateException($e);
         } catch (Exception $e) {
             throw static::translateException($e);
+        } finally {
+            $options->setTtl($previousTtl);
         }
-
-        $options->setTtl($previousTtl);
 
         return $result;
     }
@@ -224,9 +224,9 @@ class SimpleCacheDecorator implements SimpleCacheInterface
             throw static::translateException($e);
         } catch (Exception $e) {
             throw static::translateException($e);
+        } finally {
+            $options->setTtl($previousTtl);
         }
-
-        $options->setTtl($previousTtl);
 
         if (empty($result)) {
             return true;

--- a/src/Psr/SimpleCacheDecorator.php
+++ b/src/Psr/SimpleCacheDecorator.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-cache/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Cache\Psr;
+
+use Exception;
+use Psr\SimpleCache\CacheInterface as SimpleCacheInterface;
+use Throwable;
+use Zend\Cache\Exception\InvalidArgumentException as ZendCacheInvalidArgumentException;
+use Zend\Cache\Storage\FlushableInterface;
+use Zend\Cache\Storage\StorageInterface;
+
+/**
+ * Decoreate a zend-cache storage adapter for usage as a PSR-16 implementation.
+ */
+class SimpleCacheDecorator implements SimpleCacheInterface
+{
+    /**
+     * @var StorageInterface
+     */
+    private $storage;
+
+    /**
+     * Reference used by storage when calling getItem() to indicate status of
+     * operation.
+     *
+     * @var null|bool
+     */
+    private $success;
+
+    public function __construct(StorageInterface $storage)
+    {
+        $this->storage = $storage;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function get($key, $default = null)
+    {
+        $this->success = null;
+        try {
+            $result = $this->storage->getItem($key, $this->success);
+            $result = $result === null ? $default : $result;
+            return $this->success ? $result : $default;
+        } catch (Throwable $e) {
+            throw static::translateException($e);
+        } catch (Exception $e) {
+            throw static::translateException($e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function set($key, $value, $ttl = null)
+    {
+        $options = $this->storage->getOptions();
+        $previousTtl = $options->getTtl();
+        $options->setTtl($ttl);
+
+        try {
+            $result = $this->storage->setItem($key, $value);
+        } catch (Throwable $e) {
+            throw static::translateException($e);
+        } catch (Exception $e) {
+            throw static::translateException($e);
+        }
+
+        $options->setTtl($previousTtl);
+        return $result;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function delete($key)
+    {
+        try {
+            return $this->storage->removeItem($key);
+        } catch (Throwable $e) {
+            throw static::translateException($e);
+        } catch (Exception $e) {
+            throw static::translateException($e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function clear()
+    {
+        if (! $this->storage instanceof FlushableInterface) {
+            return false;
+        }
+        return $this->storage->flush();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getMultiple($keys, $default = null)
+    {
+        try {
+            $results = $this->storage->getItems($keys);
+        } catch (Throwable $e) {
+            throw static::translateException($e);
+        } catch (Exception $e) {
+            throw static::translateException($e);
+        }
+
+        foreach ($keys as $key) {
+            if (! isset($results[$key]) && null !== $default) {
+                $results[$key] = $default;
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setMultiple($values, $ttl = null)
+    {
+        $options = $this->storage->getOptions();
+        $previousTtl = $options->getTtl();
+        $options->setTtl($ttl);
+
+        try {
+            $result = $this->storage->setItems($values);
+        } catch (Throwable $e) {
+            throw static::translateException($e);
+        } catch (Exception $e) {
+            throw static::translateException($e);
+        }
+
+        $options->setTtl($previousTtl);
+        return $result;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function deleteMultiple($keys)
+    {
+        try {
+            $result = $this->storage->removeItems($keys);
+            return empty($result);
+        } catch (Throwable $e) {
+            throw static::translateException($e);
+        } catch (Exception $e) {
+            throw static::translateException($e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function has($key)
+    {
+        try {
+            return $this->storage->hasItem($key);
+        } catch (Throwable $e) {
+            throw static::translateException($e);
+        } catch (Exception $e) {
+            throw static::translateException($e);
+        }
+    }
+
+    /**
+     * @param Throwable|Exception $e
+     * @return SimpleCacheException
+     */
+    private static function translateException($e)
+    {
+        $exceptionClass = $e instanceof ZendCacheInvalidArgumentException
+            ? SimpleCacheInvalidArgumentException::class
+            : SimpleCacheException::class;
+
+        return new $exceptionClass($e->getMessage(), $e->getCode(), $e);
+    }
+}

--- a/src/Psr/SimpleCacheException.php
+++ b/src/Psr/SimpleCacheException.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-cache/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Cache\Psr;
+
+use Psr\SimpleCache\CacheException as PsrCacheException;
+use RuntimeException;
+
+class SimpleCacheException extends RuntimeException implements PsrCacheException
+{
+}

--- a/src/Psr/SimpleCacheInvalidArgumentException.php
+++ b/src/Psr/SimpleCacheInvalidArgumentException.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-cache/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Zend\Cache\Psr;
+
+use Psr\SimpleCache\InvalidArgumentException as PsrInvalidArgumentException;
+
+class SimpleCacheInvalidArgumentException extends \InvalidArgumentException implements PsrInvalidArgumentException
+{
+}

--- a/test/Psr/ExtMongoDbIntegrationTest.php
+++ b/test/Psr/ExtMongoDbIntegrationTest.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/).
+ *
+ * @link      http://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Cache\Psr;
+
+use Cache\IntegrationTests\CachePoolTest;
+use MongoDB\Client;
+use Zend\Cache\Psr\CacheItemPoolAdapter;
+use Zend\Cache\Storage\Adapter\ExtMongoDb;
+use Zend\Cache\StorageFactory;
+use Zend\Cache\Exception;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+
+class ExtMongoDbIntegrationTest extends CachePoolTest
+{
+    /**
+     * Backup default timezone
+     * @var string
+     */
+    private $tz;
+
+    /**
+     * @var ExtMongoDb
+     */
+    private $storage;
+
+    protected function setUp()
+    {
+        if (! getenv('TESTS_ZEND_CACHE_EXTMONGODB_ENABLED')) {
+            $this->markTestSkipped('Enable TESTS_ZEND_CACHE_EXTMONGODB_ENABLED to run this test');
+        }
+
+        if (! extension_loaded('mongodb') || ! class_exists(Client::class)) {
+            $this->markTestSkipped("mongodb extension is not loaded");
+        }
+
+        // set non-UTC timezone
+        $this->tz = date_default_timezone_get();
+        date_default_timezone_set('America/Vancouver');
+
+        parent::setUp();
+    }
+
+    protected function tearDown()
+    {
+        date_default_timezone_set($this->tz);
+
+        if ($this->storage) {
+            $this->storage->flush();
+        }
+
+        parent::tearDown();
+    }
+
+    public function createCachePool()
+    {
+        $storage = StorageFactory::adapterFactory('extmongodb', [
+            'server'     => getenv('TESTS_ZEND_CACHE_EXTMONGODB_CONNECTSTRING'),
+            'database'   => getenv('TESTS_ZEND_CACHE_EXTMONGODB_DATABASE'),
+            'collection' => getenv('TESTS_ZEND_CACHE_EXTMONGODB_COLLECTION'),
+        ]);
+
+        $deferredSkippedMessage = sprintf(
+            '%s storage doesn\'t support driver deferred',
+            \get_class($storage)
+        );
+        $this->skippedTests['testHasItemReturnsFalseWhenDeferredItemIsExpired'] = $deferredSkippedMessage;
+
+        return new CacheItemPoolAdapter($storage);
+    }
+}

--- a/test/Psr/SimpleCache/ApcIntegrationTest.php
+++ b/test/Psr/SimpleCache/ApcIntegrationTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-cache/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Cache\Psr\SimpleCache;
+
+use Cache\IntegrationTests\SimpleCacheTest;
+use Zend\Cache\Exception\ExtensionNotLoadedException;
+use Zend\Cache\Psr\SimpleCacheDecorator;
+use Zend\Cache\StorageFactory;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+
+class ApcIntegrationTest extends SimpleCacheTest
+{
+    /**
+     * Backup default timezone
+     * @var string
+     */
+    private $tz;
+
+    /**
+     * Restore 'apc.use_request_time'
+     *
+     * @var mixed
+     */
+    protected $iniUseRequestTime;
+
+    protected function setUp()
+    {
+        if (! getenv('TESTS_ZEND_CACHE_APC_ENABLED')) {
+            $this->markTestSkipped('Enable TESTS_ZEND_CACHE_APC_ENABLED to run this test');
+        }
+
+        // set non-UTC timezone
+        $this->tz = date_default_timezone_get();
+        date_default_timezone_set('America/Vancouver');
+
+        // needed on test expirations
+        $this->iniUseRequestTime = ini_get('apc.use_request_time');
+        ini_set('apc.use_request_time', 0);
+
+        parent::setUp();
+    }
+
+    protected function tearDown()
+    {
+        date_default_timezone_set($this->tz);
+
+        if (function_exists('apc_clear_cache')) {
+            apc_clear_cache('user');
+        }
+
+        // reset ini configurations
+        ini_set('apc.use_request_time', $this->iniUseRequestTime);
+
+        parent::tearDown();
+    }
+
+    public function createSimpleCache()
+    {
+        try {
+            $storage = StorageFactory::adapterFactory('apc');
+            return new SimpleCacheDecorator($storage);
+        } catch (ExtensionNotLoadedException $e) {
+            $this->markTestSkipped($e->getMessage());
+        } catch (ServiceNotCreatedException $e) {
+            if ($e->getPrevious() instanceof ExtensionNotLoadedException) {
+                $this->markTestSkipped($e->getMessage());
+            }
+            throw $e;
+        }
+    }
+}

--- a/test/Psr/SimpleCache/ApcuIntegrationTest.php
+++ b/test/Psr/SimpleCache/ApcuIntegrationTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-cache/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Cache\Psr\SimpleCache;
+
+use Cache\IntegrationTests\SimpleCacheTest;
+use Zend\Cache\Exception\ExtensionNotLoadedException;
+use Zend\Cache\Psr\SimpleCacheDecorator;
+use Zend\Cache\StorageFactory;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+
+class ApcuIntegrationTest extends SimpleCacheTest
+{
+    /**
+     * Backup default timezone
+     * @var string
+     */
+    private $tz;
+
+    /**
+     * Restore 'apc.use_request_time'
+     *
+     * @var mixed
+     */
+    protected $iniUseRequestTime;
+
+    protected function setUp()
+    {
+        if (! getenv('TESTS_ZEND_CACHE_APCU_ENABLED')) {
+            $this->markTestSkipped('Enable TESTS_ZEND_CACHE_APCU_ENABLED to run this test');
+        }
+
+        // set non-UTC timezone
+        $this->tz = date_default_timezone_get();
+        date_default_timezone_set('America/Vancouver');
+
+        // needed on test expirations
+        $this->iniUseRequestTime = ini_get('apc.use_request_time');
+        ini_set('apc.use_request_time', 0);
+
+        parent::setUp();
+    }
+
+    protected function tearDown()
+    {
+        date_default_timezone_set($this->tz);
+
+        if (function_exists('apc_clear_cache')) {
+            apc_clear_cache('user');
+        }
+
+        // reset ini configurations
+        ini_set('apc.use_request_time', $this->iniUseRequestTime);
+
+        parent::tearDown();
+    }
+
+    public function createSimpleCache()
+    {
+        try {
+            $storage = StorageFactory::adapterFactory('apcu');
+            return new SimpleCacheDecorator($storage);
+        } catch (ExtensionNotLoadedException $e) {
+            $this->markTestSkipped($e->getMessage());
+        } catch (ServiceNotCreatedException $e) {
+            if ($e->getPrevious() instanceof ExtensionNotLoadedException) {
+                $this->markTestSkipped($e->getMessage());
+            }
+            throw $e;
+        }
+    }
+}

--- a/test/Psr/SimpleCache/ExtMongoDbIntegrationTest.php
+++ b/test/Psr/SimpleCache/ExtMongoDbIntegrationTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-cache/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Cache\Psr\SimpleCache;
+
+use Cache\IntegrationTests\SimpleCacheTest;
+use MongoDB\Client;
+use Zend\Cache\Psr\SimpleCacheDecorator;
+use Zend\Cache\Storage\Adapter\ExtMongoDbOptions;
+use Zend\Cache\StorageFactory;
+use Zend\Cache\Exception;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+
+class ExtMongoDbIntegrationTest extends SimpleCacheTest
+{
+    /**
+     * Backup default timezone
+     * @var string
+     */
+    private $tz;
+
+    /**
+     * @var ExtMongoDb
+     */
+    private $storage;
+
+    protected function setUp()
+    {
+        if (! getenv('TESTS_ZEND_CACHE_EXTMONGODB_ENABLED')) {
+            $this->markTestSkipped('Enable TESTS_ZEND_CACHE_EXTMONGODB_ENABLED to run this test');
+        }
+
+        if (! extension_loaded('mongodb') || ! class_exists(Client::class)) {
+            $this->markTestSkipped("mongodb extension is not loaded");
+        }
+
+        // set non-UTC timezone
+        $this->tz = date_default_timezone_get();
+        date_default_timezone_set('America/Vancouver');
+
+        parent::setUp();
+    }
+
+    protected function tearDown()
+    {
+        date_default_timezone_set($this->tz);
+
+        if ($this->storage) {
+            $this->storage->flush();
+        }
+
+        parent::tearDown();
+    }
+
+    public function createSimpleCache()
+    {
+        $storage = StorageFactory::adapterFactory('extmongodb', [
+            'server'     => getenv('TESTS_ZEND_CACHE_EXTMONGODB_CONNECTSTRING'),
+            'database'   => getenv('TESTS_ZEND_CACHE_EXTMONGODB_DATABASE'),
+            'collection' => getenv('TESTS_ZEND_CACHE_EXTMONGODB_COLLECTION'),
+        ]);
+        return new SimpleCacheDecorator($storage);
+    }
+}

--- a/test/Psr/SimpleCache/FilesystemIntegrationTest.php
+++ b/test/Psr/SimpleCache/FilesystemIntegrationTest.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-cache/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Cache\Psr\SimpleCache;
+
+use Cache\IntegrationTests\SimpleCacheTest;
+use DirectoryIterator;
+use Zend\Cache\Psr\SimpleCacheDecorator;
+use Zend\Cache\Storage\Adapter\Filesystem;
+use Zend\Cache\Storage\Adapter\FilesystemOptions;
+
+class FilesystemIntegrationTest extends SimpleCacheTest
+{
+    /** @var string */
+    private $tmpCacheDir;
+
+    /** @var int */
+    protected $umask;
+
+    public function setUp()
+    {
+        $this->umask = umask();
+
+        if (getenv('TESTS_ZEND_CACHE_FILESYSTEM_DIR')) {
+            $cacheDir = getenv('TESTS_ZEND_CACHE_FILESYSTEM_DIR');
+        } else {
+            $cacheDir = sys_get_temp_dir();
+        }
+
+        $this->tmpCacheDir = @tempnam($cacheDir, 'zend_cache_test_');
+        if (! $this->tmpCacheDir) {
+            $err = error_get_last();
+            $this->fail("Can't create temporary cache directory-file: {$err['message']}");
+        } elseif (! @unlink($this->tmpCacheDir)) {
+            $err = error_get_last();
+            $this->fail("Can't remove temporary cache directory-file: {$err['message']}");
+        } elseif (! @mkdir($this->tmpCacheDir, 0777)) {
+            $err = error_get_last();
+            $this->fail("Can't create temporary cache directory: {$err['message']}");
+        }
+
+        $ttlMessage = 'Filesystem adapter does not honor TTL';
+        $keyMessage = 'Filesystem adapter supports a subset of PSR-16 characters for keys';
+
+        $this->skippedTests['testSetTtl'] = $ttlMessage;
+        $this->skippedTests['testSetMultipleTtl'] = $ttlMessage;
+        $this->skippedTests['testSetValidKeys'] = $keyMessage;
+        $this->skippedTests['testSetMultipleValidKeys'] = $keyMessage;
+
+        parent::setUp();
+    }
+
+    public function tearDown()
+    {
+        $this->removeRecursive($this->tmpCacheDir);
+
+        if ($this->umask != umask()) {
+            umask($this->umask);
+            $this->fail('Umask was not reset');
+        }
+
+        parent::tearDown();
+    }
+
+    public function removeRecursive($dir)
+    {
+        if (file_exists($dir)) {
+            $dirIt = new DirectoryIterator($dir);
+            foreach ($dirIt as $entry) {
+                $fname = $entry->getFilename();
+                if ($fname == '.' || $fname == '..') {
+                    continue;
+                }
+
+                if ($entry->isFile()) {
+                    unlink($entry->getPathname());
+                } else {
+                    $this->removeRecursive($entry->getPathname());
+                }
+            }
+
+            rmdir($dir);
+        }
+    }
+
+    public function createSimpleCache()
+    {
+        $storage = new Filesystem();
+        $storage->setOptions(new FilesystemOptions([
+            'cache_dir' => $this->tmpCacheDir,
+        ]));
+
+        return new SimpleCacheDecorator($storage);
+    }
+}

--- a/test/Psr/SimpleCache/MemcacheIntegrationTest.php
+++ b/test/Psr/SimpleCache/MemcacheIntegrationTest.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-cache/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Cache\Psr\SimpleCache;
+
+use Cache\IntegrationTests\SimpleCacheTest;
+use Zend\Cache\Psr\SimpleCacheDecorator;
+use Zend\Cache\Storage\Adapter\Memcache;
+use Zend\Cache\StorageFactory;
+use Zend\Cache\Exception;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+
+/**
+ * @require extension memcache
+ */
+class MemcacheIntegrationTest extends SimpleCacheTest
+{
+    /**
+     * Backup default timezone
+     * @var string
+     */
+    private $tz;
+
+    /**
+     * @var Memcache
+     */
+    private $storage;
+
+    protected function setUp()
+    {
+        if (! getenv('TESTS_ZEND_CACHE_MEMCACHE_ENABLED')) {
+            $this->markTestSkipped('Enable TESTS_ZEND_CACHE_MEMCACHE_ENABLED to run this test');
+        }
+
+        // set non-UTC timezone
+        $this->tz = date_default_timezone_get();
+        date_default_timezone_set('America/Vancouver');
+
+        parent::setUp();
+    }
+
+    protected function tearDown()
+    {
+        date_default_timezone_set($this->tz);
+
+        if ($this->storage) {
+            $this->storage->flush();
+        }
+
+        parent::tearDown();
+    }
+
+    public function createSimpleCache()
+    {
+        $host = getenv('TESTS_ZEND_CACHE_MEMCACHE_HOST');
+        $port = getenv('TESTS_ZEND_CACHE_MEMCACHE_PORT');
+
+        $options = [
+            'resource_id' => __CLASS__
+        ];
+        if ($host && $port) {
+            $options['servers'] = [[$host, $port]];
+        } elseif ($host) {
+            $options['servers'] = [[$host]];
+        }
+
+        try {
+            $storage = StorageFactory::adapterFactory('memcache', $options);
+            return new SimpleCacheDecorator($storage);
+        } catch (Exception\ExtensionNotLoadedException $e) {
+            $this->markTestSkipped($e->getMessage());
+        } catch (ServiceNotCreatedException $e) {
+            if ($e->getPrevious() instanceof Exception\ExtensionNotLoadedException) {
+                $this->markTestSkipped($e->getMessage());
+            }
+            throw $e;
+        }
+    }
+}

--- a/test/Psr/SimpleCache/MemcachedIntegrationTest.php
+++ b/test/Psr/SimpleCache/MemcachedIntegrationTest.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-cache/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Cache\Psr\SimpleCache;
+
+use Cache\IntegrationTests\SimpleCacheTest;
+use Zend\Cache\Psr\SimpleCacheDecorator;
+use Zend\Cache\Storage\Adapter\Memcached;
+use Zend\Cache\StorageFactory;
+use Zend\Cache\Exception;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+
+/**
+ * @require extension memcached
+ */
+class MemcachedIntegrationTest extends SimpleCacheTest
+{
+    /**
+     * Backup default timezone
+     * @var string
+     */
+    private $tz;
+
+    /**
+     * @var Memcached
+     */
+    private $storage;
+
+    protected function setUp()
+    {
+        if (! getenv('TESTS_ZEND_CACHE_MEMCACHED_ENABLED')) {
+            $this->markTestSkipped('Enable TESTS_ZEND_CACHE_MEMCACHED_ENABLED to run this test');
+        }
+
+        // set non-UTC timezone
+        $this->tz = date_default_timezone_get();
+        date_default_timezone_set('America/Vancouver');
+
+        parent::setUp();
+    }
+
+    protected function tearDown()
+    {
+        date_default_timezone_set($this->tz);
+
+        if ($this->storage) {
+            $this->storage->flush();
+        }
+
+        parent::tearDown();
+    }
+
+    public function createSimpleCache()
+    {
+        $host = getenv('TESTS_ZEND_CACHE_MEMCACHED_HOST');
+        $port = getenv('TESTS_ZEND_CACHE_MEMCACHED_PORT');
+
+        $options = [
+            'resource_id' => __CLASS__
+        ];
+        if ($host && $port) {
+            $options['servers'] = [[$host, $port]];
+        } elseif ($host) {
+            $options['servers'] = [[$host]];
+        }
+
+        try {
+            $storage = StorageFactory::adapterFactory('memcached', $options);
+            return new SimpleCacheDecorator($storage);
+        } catch (Exception\ExtensionNotLoadedException $e) {
+            $this->markTestSkipped($e->getMessage());
+        } catch (ServiceNotCreatedException $e) {
+            if ($e->getPrevious() instanceof Exception\ExtensionNotLoadedException) {
+                $this->markTestSkipped($e->getMessage());
+            }
+            throw $e;
+        }
+    }
+}

--- a/test/Psr/SimpleCache/MemoryIntegrationTest.php
+++ b/test/Psr/SimpleCache/MemoryIntegrationTest.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/).
+ *
+ * @link      http://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Cache\Psr\SimpleCache;
+
+use Cache\IntegrationTests\SimpleCacheTest;
+use Zend\Cache\Psr\SimpleCacheDecorator;
+use Zend\Cache\StorageFactory;
+
+class MemoryIntegrationTest extends SimpleCacheTest
+{
+    public function setUp()
+    {
+        $this->skippedTests['testSetTtl'] = 'Memory adapter does not honor TTL';
+        $this->skippedTests['testSetMultipleTtl'] = 'Memory adapter does not honor TTL';
+
+        $this->skippedTests['testObjectDoesNotChangeInCache'] =
+            'Memory adapter stores objects in memory; so change in references is possible';
+
+        parent::setUp();
+    }
+
+    public function createSimpleCache()
+    {
+        $storage = StorageFactory::adapterFactory('memory');
+        return new SimpleCacheDecorator($storage);
+    }
+}

--- a/test/Psr/SimpleCache/MongoDbIntegrationTest.php
+++ b/test/Psr/SimpleCache/MongoDbIntegrationTest.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-cache/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Cache\Psr\SimpleCache;
+
+use Cache\IntegrationTests\SimpleCacheTest;
+use Zend\Cache\Psr\SimpleCacheDecorator;
+use Zend\Cache\Storage\Adapter\MongoDb;
+use Zend\Cache\StorageFactory;
+use Zend\Cache\Exception;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+
+class MongoDbIntegrationTest extends SimpleCacheTest
+{
+    /**
+     * Backup default timezone
+     * @var string
+     */
+    private $tz;
+
+    /**
+     * @var MongoDb
+     */
+    private $storage;
+
+    protected function setUp()
+    {
+        if (! getenv('TESTS_ZEND_CACHE_MONGODB_ENABLED')) {
+            $this->markTestSkipped('Enable TESTS_ZEND_CACHE_MONGODB_ENABLED to run this test');
+        }
+
+        // set non-UTC timezone
+        $this->tz = date_default_timezone_get();
+        date_default_timezone_set('America/Vancouver');
+
+        parent::setUp();
+    }
+
+    protected function tearDown()
+    {
+        date_default_timezone_set($this->tz);
+
+        if ($this->storage) {
+            $this->storage->flush();
+        }
+
+        parent::tearDown();
+    }
+
+    public function createSimpleCache()
+    {
+        try {
+            $storage = StorageFactory::adapterFactory('mongodb', [
+                'server'     => getenv('TESTS_ZEND_CACHE_MONGODB_CONNECTSTRING'),
+                'database'   => getenv('TESTS_ZEND_CACHE_MONGODB_DATABASE'),
+                'collection' => getenv('TESTS_ZEND_CACHE_MONGODB_COLLECTION'),
+            ]);
+            return new SimpleCacheDecorator($storage);
+        } catch (Exception\ExtensionNotLoadedException $e) {
+            $this->markTestSkipped($e->getMessage());
+        } catch (ServiceNotCreatedException $e) {
+            if ($e->getPrevious() instanceof Exception\ExtensionNotLoadedException) {
+                $this->markTestSkipped($e->getMessage());
+            }
+            throw $e;
+        }
+    }
+}

--- a/test/Psr/SimpleCache/RedisIntegrationTest.php
+++ b/test/Psr/SimpleCache/RedisIntegrationTest.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-cache/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Cache\Psr\SimpleCache;
+
+use Cache\IntegrationTests\SimpleCacheTest;
+use Zend\Cache\Psr\SimpleCacheDecorator;
+use Zend\Cache\Storage\Adapter\Redis;
+use Zend\Cache\StorageFactory;
+use Zend\Cache\Exception;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+
+class RedisIntegrationTest extends SimpleCacheTest
+{
+    /**
+     * Backup default timezone
+     * @var string
+     */
+    private $tz;
+
+    /**
+     * @var Redis
+     */
+    private $storage;
+
+    protected function setUp()
+    {
+        if (! getenv('TESTS_ZEND_CACHE_REDIS_ENABLED')) {
+            $this->markTestSkipped('Enable TESTS_ZEND_CACHE_REDIS_ENABLED to run this test');
+        }
+
+        // set non-UTC timezone
+        $this->tz = date_default_timezone_get();
+        date_default_timezone_set('America/Vancouver');
+
+        parent::setUp();
+    }
+
+    protected function tearDown()
+    {
+        date_default_timezone_set($this->tz);
+
+        if ($this->storage) {
+            $this->storage->flush();
+        }
+
+        parent::tearDown();
+    }
+
+    public function createSimpleCache()
+    {
+        $options = ['resource_id' => __CLASS__];
+
+        if (getenv('TESTS_ZEND_CACHE_REDIS_HOST') && getenv('TESTS_ZEND_CACHE_REDIS_PORT')) {
+            $options['server'] = [getenv('TESTS_ZEND_CACHE_REDIS_HOST'), getenv('TESTS_ZEND_CACHE_REDIS_PORT')];
+        } elseif (getenv('TESTS_ZEND_CACHE_REDIS_HOST')) {
+            $options['server'] = [getenv('TESTS_ZEND_CACHE_REDIS_HOST')];
+        }
+
+        if (getenv('TESTS_ZEND_CACHE_REDIS_DATABASE')) {
+            $options['database'] = getenv('TESTS_ZEND_CACHE_REDIS_DATABASE');
+        }
+
+        if (getenv('TESTS_ZEND_CACHE_REDIS_PASSWORD')) {
+            $options['password'] = getenv('TESTS_ZEND_CACHE_REDIS_PASSWORD');
+        }
+
+        try {
+            $storage = StorageFactory::adapterFactory('redis', $options);
+            return new SimpleCacheDecorator($storage);
+        } catch (Exception\ExtensionNotLoadedException $e) {
+            $this->markTestSkipped($e->getMessage());
+        } catch (ServiceNotCreatedException $e) {
+            if ($e->getPrevious() instanceof Exception\ExtensionNotLoadedException) {
+                $this->markTestSkipped($e->getMessage());
+            }
+            throw $e;
+        }
+    }
+}

--- a/test/Psr/SimpleCache/SessionIntegrationTest.php
+++ b/test/Psr/SimpleCache/SessionIntegrationTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-cache/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Cache\Psr\SimpleCache;
+
+use Cache\IntegrationTests\SimpleCacheTest;
+use Zend\Cache\Psr\SimpleCacheDecorator;
+use Zend\Cache\StorageFactory;
+use Zend\Session\Container as SessionContainer;
+
+class SessionIntegrationTest extends SimpleCacheTest
+{
+    public function setUp()
+    {
+        if (! class_exists(SessionContainer::class)) {
+            $this->markTestSkipped('Install zend-session to enable this test');
+        }
+
+        $_SESSION = [];
+        SessionContainer::setDefaultManager(null);
+
+        $this->skippedTests['testSetTtl'] = 'Session adapter does not honor TTL';
+        $this->skippedTests['testSetMultipleTtl'] = 'Session adapter does not honor TTL';
+        $this->skippedTests['testObjectDoesNotChangeInCache'] =
+            'Session adapter stores objects in memory; so change in references is possible';
+
+        parent::setUp();
+    }
+
+    public function tearDown()
+    {
+        if (! class_exists(SessionContainer::class)) {
+            return;
+        }
+
+        $_SESSION = [];
+        SessionContainer::setDefaultManager(null);
+
+        parent::tearDown();
+    }
+
+    public function createSimpleCache()
+    {
+        $sessionContainer = new SessionContainer('Default');
+        $storage = StorageFactory::adapterfactory('session', [
+            'session_container' => $sessionContainer,
+        ]);
+        return new SimpleCacheDecorator($storage);
+    }
+}

--- a/test/Psr/SimpleCache/WinCacheIntegrationTest.php
+++ b/test/Psr/SimpleCache/WinCacheIntegrationTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-cache/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Cache\Psr\SimpleCache;
+
+use Cache\IntegrationTests\SimpleCacheTest;
+use Zend\Cache\Psr\SimpleCacheDecorator;
+use Zend\Cache\Storage\Adapter\WinCache;
+use Zend\Cache\StorageFactory;
+use Zend\Cache\Exception;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+
+/**
+ * @requires extension wincache
+ */
+class WinCacheIntegrationTest extends SimpleCacheTest
+{
+    /**
+     * Backup default timezone
+     * @var string
+     */
+    private $tz;
+
+    /**
+     * @var WinCache
+     */
+    private $storage;
+
+    protected function setUp()
+    {
+        if (! getenv('TESTS_ZEND_CACHE_WINCACHE_ENABLED')) {
+            $this->markTestSkipped('Enable TESTS_ZEND_CACHE_WINCACHE_ENABLED to run this test');
+        }
+
+        // set non-UTC timezone
+        $this->tz = date_default_timezone_get();
+        date_default_timezone_set('America/Vancouver');
+
+        parent::setUp();
+    }
+
+    protected function tearDown()
+    {
+        date_default_timezone_set($this->tz);
+
+        if ($this->storage) {
+            $this->storage->flush();
+        }
+
+        parent::tearDown();
+    }
+
+    public function createSimpleCache()
+    {
+        try {
+            $storage = StorageFactory::adapterFactory('wincache');
+            return new SimpleCacheDecorator($storage);
+        } catch (Exception\ExtensionNotLoadedException $e) {
+            $this->markTestSkipped($e->getMessage());
+        } catch (ServiceNotCreatedException $e) {
+            if ($e->getPrevious() instanceof Exception\ExtensionNotLoadedException) {
+                $this->markTestSkipped($e->getMessage());
+            }
+            throw $e;
+        }
+    }
+}

--- a/test/Psr/SimpleCache/XCacheIntegrationTest.php
+++ b/test/Psr/SimpleCache/XCacheIntegrationTest.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-cache/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Cache\Psr\SimpleCache;
+
+use Cache\IntegrationTests\SimpleCacheTest;
+use Zend\Cache\Psr\SimpleCacheDecorator;
+use Zend\Cache\StorageFactory;
+use Zend\Cache\Exception;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+
+/**
+ * @requires extension xcache
+ */
+class XCacheIntegrationTest extends SimpleCacheTest
+{
+    public function setUp()
+    {
+        if (getenv('TESTS_ZEND_CACHE_XCACHE_ENABLED') != 'true') {
+            $this->markTestSkipped('Enable TESTS_ZEND_CACHE_XCACHE_ENABLED  to run this test');
+        }
+
+        if (! extension_loaded('xcache')) {
+            try {
+                new Cache\Storage\Adapter\XCache();
+                $this->fail("Expected exception Zend\Cache\Exception\ExtensionNotLoadedException");
+            } catch (Cache\Exception\ExtensionNotLoadedException $e) {
+                $this->markTestSkipped($e->getMessage());
+            }
+        }
+
+        if (PHP_SAPI == 'cli' && version_compare(phpversion('xcache'), '3.1.0') < 0) {
+            try {
+                new Cache\Storage\Adapter\XCache();
+                $this->fail("Expected exception Zend\Cache\Exception\ExtensionNotLoadedException");
+            } catch (Cache\Exception\ExtensionNotLoadedException $e) {
+                $this->markTestSkipped($e->getMessage());
+            }
+        }
+
+        if ((int)ini_get('xcache.var_size') <= 0) {
+            try {
+                new Cache\Storage\Adapter\XCache();
+                $this->fail("Expected exception Zend\Cache\Exception\ExtensionNotLoadedException");
+            } catch (Cache\Exception\ExtensionNotLoadedException $e) {
+                $this->markTestSkipped($e->getMessage());
+            }
+        }
+
+        $this->skippedTests['testSetTtl'] = 'XCache adapter does not honor TTL';
+        $this->skippedTests['testSetMultipleTtl'] = 'XCache adapter does not honor TTL';
+
+        parent::setUp();
+    }
+
+    public function createSimpleCache()
+    {
+        try {
+            $storage = StorageFactory::adapterFactory('xcache', [
+                'admin_auth' => getenv('TESTS_ZEND_CACHE_XCACHE_ADMIN_AUTH') ?: false,
+                'admin_user' => getenv('TESTS_ZEND_CACHE_XCACHE_ADMIN_USER') ?: '',
+                'admin_pass' => getenv('TESTS_ZEND_CACHE_XCACHE_ADMIN_PASS') ?: '',
+            ]);
+            return new SimpleCacheDecorator($storage);
+        } catch (Exception\ExtensionNotLoadedException $e) {
+            $this->markTestSkipped($e->getMessage());
+        } catch (ServiceNotCreatedException $e) {
+            if ($e->getPrevious() instanceof Exception\ExtensionNotLoadedException) {
+                $this->markTestSkipped($e->getMessage());
+            }
+            throw $e;
+        }
+    }
+}

--- a/test/Psr/SimpleCache/ZendServerDiskIntegrationTest.php
+++ b/test/Psr/SimpleCache/ZendServerDiskIntegrationTest.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-cache/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Cache\Psr\SimpleCache;
+
+use Cache\IntegrationTests\SimpleCacheTest;
+use Zend\Cache\Psr\SimpleCacheDecorator;
+use Zend\Cache\StorageFactory;
+use Zend\Cache\Exception;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+
+class ZendServerDiskIntegrationTest extends SimpleCacheTest
+{
+    /**
+     * Backup default timezone
+     * @var string
+     */
+    private $tz;
+
+    protected function setUp()
+    {
+        if (! getenv('TESTS_ZEND_CACHE_ZEND_SERVER_ENABLED')) {
+            $this->markTestSkipped('Enable TESTS_ZEND_CACHE_ZEND_SERVER_ENABLED to run this test');
+        }
+
+        // set non-UTC timezone
+        $this->tz = date_default_timezone_get();
+        date_default_timezone_set('America/Vancouver');
+
+        parent::setUp();
+    }
+
+    protected function tearDown()
+    {
+        date_default_timezone_set($this->tz);
+
+        if (function_exists('zend_disk_cache_clear')) {
+            zend_disk_cache_clear();
+        }
+
+        parent::tearDown();
+    }
+
+    public function createSimpleCache()
+    {
+        try {
+            $storage = StorageFactory::adapterFactory('zendserverdisk');
+            return new SimpleCacheDecorator($storage);
+        } catch (Exception\ExtensionNotLoadedException $e) {
+            $this->markTestSkipped($e->getMessage());
+        } catch (ServiceNotCreatedException $e) {
+            if ($e->getPrevious() instanceof Exception\ExtensionNotLoadedException) {
+                $this->markTestSkipped($e->getMessage());
+            }
+            throw $e;
+        }
+    }
+}

--- a/test/Psr/SimpleCache/ZendServerShmIntegrationTest.php
+++ b/test/Psr/SimpleCache/ZendServerShmIntegrationTest.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-cache/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Cache\Psr\SimpleCache;
+
+use Cache\IntegrationTests\SimpleCacheTest;
+use Zend\Cache\Psr\SimpleCacheDecorator;
+use Zend\Cache\StorageFactory;
+use Zend\Cache\Exception;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+
+class ZendServerShmIntegrationTest extends SimpleCacheTest
+{
+    /**
+     * Backup default timezone
+     * @var string
+     */
+    private $tz;
+
+    protected function setUp()
+    {
+        if (! getenv('TESTS_ZEND_CACHE_ZEND_SERVER_ENABLED')) {
+            $this->markTestSkipped('Enable TESTS_ZEND_CACHE_ZEND_SERVER_ENABLED to run this test');
+        }
+
+        if (! function_exists('zend_shm_cache_store') || PHP_SAPI == 'cli') {
+            $this->markTestSkipped("Missing 'zend_shm_cache_*' functions or running from SAPI 'cli'");
+        }
+
+        // set non-UTC timezone
+        $this->tz = date_default_timezone_get();
+        date_default_timezone_set('America/Vancouver');
+
+        parent::setUp();
+    }
+
+    protected function tearDown()
+    {
+        date_default_timezone_set($this->tz);
+
+        if (function_exists('zend_shm_cache_clear')) {
+            zend_disk_cache_clear();
+        }
+
+        parent::tearDown();
+    }
+
+    public function createSimpleCache()
+    {
+        try {
+            $storage = StorageFactory::adapterFactory('zendservershm');
+            return new SimpleCacheDecorator($storage);
+        } catch (Exception\ExtensionNotLoadedException $e) {
+            $this->markTestSkipped($e->getMessage());
+        } catch (ServiceNotCreatedException $e) {
+            if ($e->getPrevious() instanceof Exception\ExtensionNotLoadedException) {
+                $this->markTestSkipped($e->getMessage());
+            }
+            throw $e;
+        }
+    }
+}

--- a/test/Psr/SimpleCacheDecoratorTest.php
+++ b/test/Psr/SimpleCacheDecoratorTest.php
@@ -626,7 +626,9 @@ class SimpleCacheDecoratorTest extends TestCase
             'string' => false,
         ]);
         $storage->getOptions()->will([$options, 'reveal']);
-        $storage->setItems($serializedValues)->willReturn([]);
+        $storage->setItem('one', $serializedValues['one'])->willReturn(true);
+        $storage->setItem('two', $serializedValues['two'])->willReturn(true);
+        $storage->setItem('three', $serializedValues['three'])->willReturn(true);
 
         $cache = new SimpleCacheDecorator($storage->reveal());
 

--- a/test/Psr/SimpleCacheDecoratorTest.php
+++ b/test/Psr/SimpleCacheDecoratorTest.php
@@ -357,7 +357,7 @@ class SimpleCacheDecoratorTest extends TestCase
                 $this
                     ->setTtl($ttl)
                     ->will(function () use ($originalTtl) {
-                        $this->setTtl($originalTtl)->shouldNotBeCalled();
+                        $this->setTtl($originalTtl)->shouldBeCalled();
                     });
                 return $originalTtl;
             });
@@ -719,7 +719,7 @@ class SimpleCacheDecoratorTest extends TestCase
                 $this
                     ->setTtl($ttl)
                     ->will(function () use ($originalTtl) {
-                        $this->setTtl($originalTtl)->shouldNotBeCalled();
+                        $this->setTtl($originalTtl)->shouldBeCalled();
                     });
                 return $originalTtl;
             });

--- a/test/Psr/SimpleCacheDecoratorTest.php
+++ b/test/Psr/SimpleCacheDecoratorTest.php
@@ -1,0 +1,382 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-cache/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Cache\Psr;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Psr\SimpleCache\CacheInterface as SimpleCacheInterface;
+use ReflectionProperty;
+use Zend\Cache\Exception;
+use Zend\Cache\Psr\SimpleCacheDecorator;
+use Zend\Cache\Psr\SimpleCacheInvalidArgumentException;
+use Zend\Cache\Psr\SimpleCacheException;
+use Zend\Cache\Storage\Adapter\AdapterOptions;
+use Zend\Cache\Storage\FlushableInterface;
+use Zend\Cache\Storage\StorageInterface;
+
+/**
+ * Test the PSR-16 decorator.
+ *
+ * Note to maintainers: the try/catch blocks are done on purpose within this
+ * class, instead of expectException*(). This is due to the fact that the
+ * decorator is expected to re-throw any caught exceptions as PSR-16 exception
+ * types. The class passes the original exception as the previous exception
+ * when doing so, and the only way to test that this has happened is to use
+ * try/catch blocks and assert identity against the result of getPrevious().
+ */
+class SimpleCacheDecoratorTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->options = $this->prophesize(AdapterOptions::class);
+        $this->storage = $this->prophesize(StorageInterface::class);
+        $this->cache = new SimpleCacheDecorator($this->storage->reveal());
+    }
+
+    public function setSuccessReference(SimpleCacheDecorator $cache, $success)
+    {
+        $r = new ReflectionProperty($cache, 'success');
+        $r->setAccessible(true);
+        $r->setValue($cache, $success);
+    }
+
+    public function testItIsASimpleCacheImplementation()
+    {
+        $this->assertInstanceOf(SimpleCacheInterface::class, $this->cache);
+    }
+
+    public function testGetReturnsDefaultValueWhenUnderlyingStorageDoesNotContainItem()
+    {
+        $testCase = $this;
+        $cache = $this->cache;
+        $this->storage
+            ->getItem('key', Argument::any())
+            ->will(function () use ($testCase, $cache) {
+                // Indicating lookup succeeded, but...
+                $testCase->setSuccessReference($cache, true);
+                // null === not found
+                return null;
+            });
+
+        $this->assertSame('default', $this->cache->get('key', 'default'));
+    }
+
+    public function testGetReturnsDefaultValueWhenStorageIndicatesFailure()
+    {
+        $testCase = $this;
+        $cache = $this->cache;
+        $this->storage
+            ->getItem('key', Argument::any())
+            ->will(function () use ($testCase, $cache) {
+                // Indicating failure to lookup
+                $testCase->setSuccessReference($cache, false);
+                return false;
+            });
+
+        $this->assertSame('default', $this->cache->get('key', 'default'));
+    }
+
+    public function testGetReturnsValueReturnedByStorage()
+    {
+        $testCase = $this;
+        $cache = $this->cache;
+        $expected = 'returned value';
+
+        $this->storage
+            ->getItem('key', Argument::any())
+            ->will(function () use ($testCase, $cache, $expected) {
+                // Indicating lookup success
+                $testCase->setSuccessReference($cache, true);
+                return $expected;
+            });
+
+        $this->assertSame($expected, $this->cache->get('key', 'default'));
+    }
+
+    public function testGetShouldReRaiseExceptionThrownByStorage()
+    {
+        $exception = new Exception\ExtensionNotLoadedException('failure', 500);
+        $this->storage
+            ->getItem('key', Argument::any())
+            ->willThrow($exception);
+
+        try {
+            $this->cache->get('key', 'default');
+            $this->fail('Exception should have been raised');
+        } catch (SimpleCacheException $e) {
+            $this->assertSame($exception->getMessage(), $e->getMessage());
+            $this->assertSame($exception->getCode(), $e->getCode());
+            $this->assertSame($exception, $e->getPrevious());
+        }
+    }
+
+    public function testSetProxiesToStorageAndModifiesAndResetsOptions()
+    {
+        $originalTtl = 600;
+        $ttl = 86400;
+
+        $this->options
+            ->getTtl()
+            ->will(function () use ($ttl, $originalTtl) {
+                $this
+                    ->setTtl($ttl)
+                    ->will(function () use ($originalTtl) {
+                        $this->setTtl($originalTtl)->shouldBeCalled();
+                    });
+                return $originalTtl;
+            });
+
+        $this->storage->getOptions()->will([$this->options, 'reveal']);
+        $this->storage->setItem('key', 'value')->willReturn(true);
+
+        $this->assertTrue($this->cache->set('key', 'value', $ttl));
+    }
+
+    public function testSetShouldReRaiseExceptionThrownByStorage()
+    {
+        $originalTtl = 600;
+        $ttl = 86400;
+
+        $this->options
+            ->getTtl()
+            ->will(function () use ($ttl, $originalTtl) {
+                $this
+                    ->setTtl($ttl)
+                    ->will(function () use ($originalTtl) {
+                        $this->setTtl($originalTtl)->shouldNotBeCalled();
+                    });
+                return $originalTtl;
+            });
+
+        $this->storage->getOptions()->will([$this->options, 'reveal']);
+
+        $exception = new Exception\ExtensionNotLoadedException('failure', 500);
+        $this->storage->setItem('key', 'value')->willThrow($exception);
+
+        try {
+            $this->cache->set('key', 'value', $ttl);
+            $this->fail('Exception should have been raised');
+        } catch (SimpleCacheException $e) {
+            $this->assertSame($exception->getMessage(), $e->getMessage());
+            $this->assertSame($exception->getCode(), $e->getCode());
+            $this->assertSame($exception, $e->getPrevious());
+        }
+    }
+
+    public function testDeleteShouldProxyToStorage()
+    {
+        $this->storage->removeItem('key')->willReturn(true);
+        $this->assertTrue($this->cache->delete('key'));
+    }
+
+    public function testDeleteShouldReRaiseExceptionThrownByStorage()
+    {
+        $exception = new Exception\ExtensionNotLoadedException('failure', 500);
+        $this->storage->removeItem('key')->willThrow($exception);
+
+        try {
+            $this->cache->delete('key');
+            $this->fail('Exception should have been raised');
+        } catch (SimpleCacheException $e) {
+            $this->assertSame($exception->getMessage(), $e->getMessage());
+            $this->assertSame($exception->getCode(), $e->getCode());
+            $this->assertSame($exception, $e->getPrevious());
+        }
+    }
+
+    public function testClearReturnsFalseIfStorageIsNotFlushable()
+    {
+        $this->assertFalse($this->cache->clear());
+    }
+
+    public function testClearProxiesToStorageIfStorageIsFlushable()
+    {
+        $storage = $this->prophesize(StorageInterface::class);
+        $storage->willImplement(FlushableInterface::class);
+        $storage->flush()->willReturn(true);
+
+        $cache = new SimpleCacheDecorator($storage->reveal());
+        $this->assertTrue($cache->clear());
+    }
+
+    public function testGetMultipleProxiesToStorageAndProvidesDefaultsForUnfoundKeysWhenNonNullDefaultPresent()
+    {
+        $keys = ['one', 'two', 'three'];
+        $expected = [
+            'one' => 1,
+            'two' => 'default',
+            'three' => 3,
+        ];
+
+        $this->storage
+            ->getItems($keys)
+            ->willReturn([
+                'one' => 1,
+                'three' => 3,
+            ]);
+
+        $this->assertEquals($expected, $this->cache->getMultiple($keys, 'default'));
+    }
+
+    public function testGetMultipleProxiesToStorageAndOmitsValuesForUnfoundKeysWhenNullDefaultPresent()
+    {
+        $keys = ['one', 'two', 'three'];
+        $expected = [
+            'one' => 1,
+            'three' => 3,
+        ];
+
+        $this->storage
+            ->getItems($keys)
+            ->willReturn([
+                'one' => 1,
+                'three' => 3,
+            ]);
+
+        $this->assertEquals($expected, $this->cache->getMultiple($keys));
+    }
+
+    public function testGetMultipleReRaisesExceptionFromStorage()
+    {
+        $keys = ['one', 'two', 'three'];
+        $exception = new Exception\ExtensionNotLoadedException('failure', 500);
+
+        $this->storage
+            ->getItems($keys)
+            ->willThrow($exception);
+
+        try {
+            $this->cache->getMultiple($keys);
+            $this->fail('Exception should have been raised');
+        } catch (SimpleCacheException $e) {
+            $this->assertSame($exception->getMessage(), $e->getMessage());
+            $this->assertSame($exception->getCode(), $e->getCode());
+            $this->assertSame($exception, $e->getPrevious());
+        }
+    }
+
+    public function testSetMultipleProxiesToStorageAndModifiesAndResetsOptions()
+    {
+        $originalTtl = 600;
+        $ttl = 86400;
+
+        $this->options
+            ->getTtl()
+            ->will(function () use ($ttl, $originalTtl) {
+                $this
+                    ->setTtl($ttl)
+                    ->will(function () use ($originalTtl) {
+                        $this->setTtl($originalTtl)->shouldBeCalled();
+                    });
+                return $originalTtl;
+            });
+
+        $this->storage->getOptions()->will([$this->options, 'reveal']);
+
+        $values = ['one' => 1, 'three' => 3];
+
+        $this->storage->setItems($values)->willReturn(true);
+
+        $this->assertTrue($this->cache->setMultiple($values, $ttl));
+    }
+
+    public function testSetMultipleReRaisesExceptionFromStorage()
+    {
+        $originalTtl = 600;
+        $ttl = 86400;
+
+        $this->options
+            ->getTtl()
+            ->will(function () use ($ttl, $originalTtl) {
+                $this
+                    ->setTtl($ttl)
+                    ->will(function () use ($originalTtl) {
+                        $this->setTtl($originalTtl)->shouldNotBeCalled();
+                    });
+                return $originalTtl;
+            });
+
+        $this->storage->getOptions()->will([$this->options, 'reveal']);
+
+        $exception = new Exception\ExtensionNotLoadedException('failure', 500);
+        $values = ['one' => 1, 'three' => 3];
+
+        $this->storage->setItems($values)->willThrow($exception);
+
+        try {
+            $this->cache->setMultiple($values, $ttl);
+            $this->fail('Exception should have been raised');
+        } catch (SimpleCacheException $e) {
+            $this->assertSame($exception->getMessage(), $e->getMessage());
+            $this->assertSame($exception->getCode(), $e->getCode());
+            $this->assertSame($exception, $e->getPrevious());
+        }
+    }
+
+    public function testDeleteMultipleProxiesToStorageAndReturnsTrueWhenStorageReturnsEmptyArray()
+    {
+        $keys = ['one', 'two', 'three'];
+        $this->storage->removeItems($keys)->willReturn([]);
+        $this->assertTrue($this->cache->deleteMultiple($keys));
+    }
+
+    public function testDeleteMultipleProxiesToStorageAndReturnsFalseIfStorageReturnsNonEmptyArray()
+    {
+        $keys = ['one', 'two', 'three'];
+        $this->storage->removeItems($keys)->willReturn(['two']);
+        $this->assertFalse($this->cache->deleteMultiple($keys));
+    }
+
+    public function testDeleteMultipleReRaisesExceptionThrownByStorage()
+    {
+        $keys = [1, 2, 3];
+        $exception = new Exception\InvalidArgumentException('bad key', 500);
+        $this->storage->removeItems($keys)->willThrow($exception);
+
+        try {
+            $this->cache->deleteMultiple($keys);
+            $this->fail('Exception should have been raised');
+        } catch (SimpleCacheInvalidArgumentException $e) {
+            $this->assertSame($exception->getMessage(), $e->getMessage());
+            $this->assertSame($exception->getCode(), $e->getCode());
+            $this->assertSame($exception, $e->getPrevious());
+        }
+    }
+
+    public function hasResultProvider()
+    {
+        return [
+            'true' => [true],
+            'false' => [false],
+        ];
+    }
+
+    /**
+     * @dataProvider hasResultProvider
+     */
+    public function testHasProxiesToStorage($result)
+    {
+        $this->storage->hasItem('key')->willReturn($result);
+        $this->assertSame($result, $this->cache->has('key'));
+    }
+
+    public function testHasReRaisesExceptionThrownByStorage()
+    {
+        $exception = new Exception\ExtensionNotLoadedException('failure', 500);
+        $this->storage->hasItem('key')->willThrow($exception);
+
+        try {
+            $this->cache->has('key');
+            $this->fail('Exception should have been raised');
+        } catch (SimpleCacheException $e) {
+            $this->assertSame($exception->getMessage(), $e->getMessage());
+            $this->assertSame($exception->getCode(), $e->getCode());
+            $this->assertSame($exception, $e->getPrevious());
+        }
+    }
+}

--- a/test/Psr/SimpleCacheDecoratorTest.php
+++ b/test/Psr/SimpleCacheDecoratorTest.php
@@ -52,13 +52,14 @@ class SimpleCacheDecoratorTest extends TestCase
     public function invalidKeyProvider()
     {
         return [
-            'brace-start'   => ['key{'],
-            'brace-end'     => ['key}'],
-            'paren-start'   => ['key('],
-            'paren-end'     => ['key)'],
-            'forward-slash' => ['ns/key'],
-            'back-slash'    => ['ns\key'],
-            'at'            => ['ns@key'],
+            'brace-start'   => ['key{', 'cannot contain'],
+            'brace-end'     => ['key}', 'cannot contain'],
+            'paren-start'   => ['key(', 'cannot contain'],
+            'paren-end'     => ['key)', 'cannot contain'],
+            'forward-slash' => ['ns/key', 'cannot contain'],
+            'back-slash'    => ['ns\key', 'cannot contain'],
+            'at'            => ['ns@key', 'cannot contain'],
+            'too-long'      => [str_repeat('abcd', 17), 'too long'],
         ];
     }
 
@@ -156,12 +157,14 @@ class SimpleCacheDecoratorTest extends TestCase
 
     /**
      * @dataProvider invalidKeyProvider
+     * @param string $key
+     * @param string $expectedMessage
      */
-    public function testSetShouldRaisePsrInvalidArgumentExceptionForInvalidKeys($key)
+    public function testSetShouldRaisePsrInvalidArgumentExceptionForInvalidKeys($key, $expectedMessage)
     {
         $this->storage->getOptions()->shouldNotBeCalled();
         $this->expectException(SimpleCacheInvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid key');
+        $this->expectExceptionMessage($expectedMessage);
         $this->cache->set($key, 'value');
     }
 
@@ -315,12 +318,14 @@ class SimpleCacheDecoratorTest extends TestCase
 
     /**
      * @dataProvider invalidKeyProvider
+     * @param string $key
+     * @param string $expectedMessage
      */
-    public function testSetMultipleShouldRaisePsrInvalidArgumentExceptionForInvalidKeys($key)
+    public function testSetMultipleShouldRaisePsrInvalidArgumentExceptionForInvalidKeys($key, $expectedMessage)
     {
         $this->storage->getOptions()->shouldNotBeCalled();
         $this->expectException(SimpleCacheInvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid key');
+        $this->expectExceptionMessage($expectedMessage);
         $this->cache->setMultiple([$key => 'value']);
     }
 

--- a/test/Psr/SimpleCacheDecoratorTest.php
+++ b/test/Psr/SimpleCacheDecoratorTest.php
@@ -45,6 +45,23 @@ class SimpleCacheDecoratorTest extends TestCase
         $r->setValue($cache, $success);
     }
 
+    /**
+     * Set of string key names that should be considered invalid for operations
+     * that create cache entries.
+     */
+    public function invalidKeyProvider()
+    {
+        return [
+            'brace-start'   => ['key{'],
+            'brace-end'     => ['key}'],
+            'paren-start'   => ['key('],
+            'paren-end'     => ['key)'],
+            'forward-slash' => ['ns/key'],
+            'back-slash'    => ['ns\key'],
+            'at'            => ['ns@key'],
+        ];
+    }
+
     public function testItIsASimpleCacheImplementation()
     {
         $this->assertInstanceOf(SimpleCacheInterface::class, $this->cache);
@@ -135,6 +152,17 @@ class SimpleCacheDecoratorTest extends TestCase
         $this->storage->setItem('key', 'value')->willReturn(true);
 
         $this->assertTrue($this->cache->set('key', 'value', $ttl));
+    }
+
+    /**
+     * @dataProvider invalidKeyProvider
+     */
+    public function testSetShouldRaisePsrInvalidArgumentExceptionForInvalidKeys($key)
+    {
+        $this->storage->getOptions()->shouldNotBeCalled();
+        $this->expectException(SimpleCacheInvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid key');
+        $this->cache->set($key, 'value');
     }
 
     public function testSetShouldReRaiseExceptionThrownByStorage()
@@ -283,6 +311,17 @@ class SimpleCacheDecoratorTest extends TestCase
         $this->storage->setItems($values)->willReturn(true);
 
         $this->assertTrue($this->cache->setMultiple($values, $ttl));
+    }
+
+    /**
+     * @dataProvider invalidKeyProvider
+     */
+    public function testSetMultipleShouldRaisePsrInvalidArgumentExceptionForInvalidKeys($key)
+    {
+        $this->storage->getOptions()->shouldNotBeCalled();
+        $this->expectException(SimpleCacheInvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid key');
+        $this->cache->setMultiple([$key => 'value']);
     }
 
     public function testSetMultipleReRaisesExceptionFromStorage()


### PR DESCRIPTION
This patch serves as an alternative to #126, based on [a comment by @marc-mabe to that patch](https://github.com/zendframework/zend-cache/pull/126#issuecomment-271992110).

The patch adds a new class, `Zend\Cache\Psr\SimpleCacheDecorator`, which accepts a zend-cache storage instance to its constructor, and then proxies to it via the methods that implement the PSR-16 `CacheInterface`. The approach is simpler than that in #126 as it does not require testing against every adapter; we can test the decorator against a mock of the `StorageInterface`, validating its behavior. The tests provided also ensure that any exceptions thrown by the underlying storage operations are re-cast to PSR-16 implementations.

This approach may miss a few details; each of @marc-mabe, @kynx, and @boesing raised a few issues in #126 that I am uncertain if this approach covers. I'd love feedback before I merge this.

#### TODO

- [x] Validate keys to ensure they do not contain reserved characters
- [x] Validate keys to ensure they do not exceed maximum length
- [x] Detect whether the zend-cache adapter requires serialization; if so, serialize values before storage, and deserialize on retrieval.
- [x] Implement TTL capabilities per PSR-16:
  - [x] If a negative or zero TTL is provided, have `set()` and `setMultiple()` remove the item(s) from the cache (instead of storing).
  - [x] If the adapter does not support TTL semantics, have `set()` and `setMultiple()` return boolean false for non-null, `>0` TTL values.
- [ ] Implement integration tests for as many adapters as make sense.