### PR TITLE
Handle item removal consistent with PSR-16 from SimpleCacheDecorator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -126,6 +126,8 @@ matrix:
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
+  # Prevent phpunit from timing out by letting it run longer
+  - composer global config process-timeout 600
 
 install:
   # prevent PECL from enabling the extension by default, see https://pear.php.net/bugs/bug.php?id=21007

--- a/src/Psr/SimpleCache/SimpleCacheDecorator.php
+++ b/src/Psr/SimpleCache/SimpleCacheDecorator.php
@@ -135,12 +135,8 @@ class SimpleCacheDecorator implements SimpleCacheInterface
     {
         $this->validateKey($key);
 
-        if (! $this->storage->hasItem($key)) {
-            return true;
-        }
-
         try {
-            return (bool) $this->storage->removeItem($key);
+            return null !== $this->storage->removeItem($key);
         } catch (Throwable $e) {
             return false;
         } catch (Exception $e) {

--- a/src/Psr/SimpleCache/SimpleCacheDecorator.php
+++ b/src/Psr/SimpleCache/SimpleCacheDecorator.php
@@ -142,9 +142,9 @@ class SimpleCacheDecorator implements SimpleCacheInterface
         try {
             return $this->storage->removeItem($key);
         } catch (Throwable $e) {
-            throw static::translateException($e);
+            return false;
         } catch (Exception $e) {
-            throw static::translateException($e);
+            return false;
         }
     }
 
@@ -257,9 +257,9 @@ class SimpleCacheDecorator implements SimpleCacheInterface
         try {
             $result = $this->storage->removeItems($keys);
         } catch (Throwable $e) {
-            throw static::translateException($e);
+            return false;
         } catch (Exception $e) {
-            throw static::translateException($e);
+            return false;
         }
 
         if (empty($result)) {

--- a/src/Psr/SimpleCache/SimpleCacheDecorator.php
+++ b/src/Psr/SimpleCache/SimpleCacheDecorator.php
@@ -140,7 +140,7 @@ class SimpleCacheDecorator implements SimpleCacheInterface
         }
 
         try {
-            return $this->storage->removeItem($key);
+            return (bool) $this->storage->removeItem($key);
         } catch (Throwable $e) {
             return false;
         } catch (Exception $e) {

--- a/test/Psr/SimpleCache/SimpleCacheDecoratorTest.php
+++ b/test/Psr/SimpleCache/SimpleCacheDecoratorTest.php
@@ -358,20 +358,13 @@ class SimpleCacheDecoratorTest extends TestCase
         $this->assertTrue($this->cache->delete('key'));
     }
 
-    public function testDeleteShouldReRaiseExceptionThrownByStorage()
+    public function testDeleteShouldReturnFalseWhenExceptionThrownByStorage()
     {
         $exception = new Exception\ExtensionNotLoadedException('failure', 500);
         $this->storage->hasItem('key')->willReturn(true);
         $this->storage->removeItem('key')->willThrow($exception);
 
-        try {
-            $this->cache->delete('key');
-            $this->fail('Exception should have been raised');
-        } catch (SimpleCacheException $e) {
-            $this->assertSame($exception->getMessage(), $e->getMessage());
-            $this->assertSame($exception->getCode(), $e->getCode());
-            $this->assertSame($exception, $e->getPrevious());
-        }
+        $this->assertFalse($this->cache->delete('key'));
     }
 
     public function testClearReturnsFalseIfStorageIsNotFlushable()
@@ -709,20 +702,13 @@ class SimpleCacheDecoratorTest extends TestCase
         $this->assertTrue($this->cache->deleteMultiple($keys));
     }
 
-    public function testDeleteMultipleReRaisesExceptionThrownByStorage()
+    public function testDeleteMultipleReturnFalseWhenExceptionThrownByStorage()
     {
         $keys = ['one', 'two', 'three'];
         $exception = new Exception\InvalidArgumentException('bad key', 500);
         $this->storage->removeItems($keys)->willThrow($exception);
 
-        try {
-            $this->cache->deleteMultiple($keys);
-            $this->fail('Exception should have been raised');
-        } catch (SimpleCacheInvalidArgumentException $e) {
-            $this->assertSame($exception->getMessage(), $e->getMessage());
-            $this->assertSame($exception->getCode(), $e->getCode());
-            $this->assertSame($exception, $e->getPrevious());
-        }
+        $this->assertFalse($this->cache->deleteMultiple($keys));
     }
 
     public function hasResultProvider()

--- a/test/Psr/SimpleCache/SimpleCacheDecoratorTest.php
+++ b/test/Psr/SimpleCache/SimpleCacheDecoratorTest.php
@@ -346,22 +346,19 @@ class SimpleCacheDecoratorTest extends TestCase
 
     public function testDeleteShouldProxyToStorage()
     {
-        $this->storage->hasItem('key')->willReturn(true);
         $this->storage->removeItem('key')->willReturn(true);
         $this->assertTrue($this->cache->delete('key'));
     }
 
     public function testDeleteShouldReturnTrueWhenItemDoesNotExist()
     {
-        $this->storage->hasItem('key')->willReturn(false);
-        $this->storage->removeItem('key')->shouldNotBeCalled();
+        $this->storage->removeItem('key')->willReturn(false);
         $this->assertTrue($this->cache->delete('key'));
     }
 
     public function testDeleteShouldReturnFalseWhenExceptionThrownByStorage()
     {
         $exception = new Exception\ExtensionNotLoadedException('failure', 500);
-        $this->storage->hasItem('key')->willReturn(true);
         $this->storage->removeItem('key')->willThrow($exception);
 
         $this->assertFalse($this->cache->delete('key'));


### PR DESCRIPTION
PSR-16 states that `delete()` and `deleteMultiple()` should return false in the case of an error, not throw an exception. This patch modifies the catch statements of each to `return false` accordingly.

Additionally, it modifies the `return $this->storage->removeItem($key)` to read `return (bool) $this->storage->removeItem($key);`. When using the `ExceptionHandler` plugin, it's possible for a `void` or `null` return value due to never receiving a result from the adapter for the operation; by casting to boolean, we ensure it properly indicates failure per the PSR-16 specification.

This patch also documents pitfalls with `delete()` and `deleteMultiple()` with regards to plugins changing the throw behavior and/or altering the result.

Finally, this patch documents which adapters require the Serializer plugin when used with PSR-16.

Alternative to #160 
Fixes #158 