### PR TITLE
#165 fix success bool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#165](https://github.com/zendframework/zend-cache/issues/165) On not found any cache entry the `$success` attribute is `false`.
 
 ## 2.8.0 - 2018-04-24
 

--- a/src/Storage/Adapter/Memcached.php
+++ b/src/Storage/Adapter/Memcached.php
@@ -206,8 +206,8 @@ class Memcached extends AbstractAdapter implements
         if (func_num_args() > 2) {
             if (defined('Memcached::GET_EXTENDED')) {
                 $output = $memc->get($internalKey, null, \Memcached::GET_EXTENDED);
-                $casToken = $output['cas'];
-                $result = $output['value'] ?? false;
+                $casToken = $output ? $output['cas'] : $casToken;
+                $result = $output ? $output['value'] : false;
             } else {
                 $result = $memc->get($internalKey, null, $casToken);
             }

--- a/src/Storage/Adapter/Memcached.php
+++ b/src/Storage/Adapter/Memcached.php
@@ -207,7 +207,7 @@ class Memcached extends AbstractAdapter implements
             if (defined('Memcached::GET_EXTENDED')) {
                 $output = $memc->get($internalKey, null, \Memcached::GET_EXTENDED);
                 $casToken = $output['cas'];
-                $result = $output['value'];
+                $result = $output['value'] ?? false;
             } else {
                 $result = $memc->get($internalKey, null, $casToken);
             }


### PR DESCRIPTION
This fix solve the problem if there could not find a memcache item the `$success` attribute is set correctly to `false` (see #165).