### PR TITLE
Fixed typo in variable name

### DIFF
--- a/src/Storage/Adapter/Filesystem.php
+++ b/src/Storage/Adapter/Filesystem.php
@@ -327,7 +327,7 @@ class Filesystem extends AbstractAdapter implements
         $filespec = $this->getFileSpec($key);
 
         if (! $tags) {
-            $this->unlink($this->formatTagFilename($filespac));
+            $this->unlink($this->formatTagFilename($filespec));
             return true;
         }
 

--- a/test/Storage/Adapter/FilesystemTest.php
+++ b/test/Storage/Adapter/FilesystemTest.php
@@ -608,4 +608,15 @@ class FilesystemTest extends CommonAdapterTest
         $this->_options->setTagSuffix('.cache');
         $this->assertSame('.cache', $this->_options->getTagSuffix());
     }
+
+    public function testEmptyTagsArrayClearsTags()
+    {
+        $key = 'key';
+        $tags = ['tag1', 'tag2', 'tag3'];
+        $this->assertTrue($this->_storage->setItem($key, 100));
+        $this->assertTrue($this->_storage->setTags($key, $tags));
+        $this->assertNotEmpty($this->_storage->getTags($key));
+        $this->assertTrue($this->_storage->setTags($key, []));
+        $this->assertEmpty($this->_storage->getTags($key));
+    }
 }


### PR DESCRIPTION
There was a typo in setTags in the filesystem adapter.