### PR TITLE
Fix typos in exception messages and code comments

### DIFF
--- a/src/Pattern/CaptureCache.php
+++ b/src/Pattern/CaptureCache.php
@@ -297,7 +297,7 @@ class CaptureCache extends AbstractPattern
         ErrorHandler::start();
 
         if ($perm === false) {
-            // build-in mkdir function is enough
+            // built-in mkdir function is enough
 
             $umask = ($umask !== false) ? umask($umask) : false;
             $res   = mkdir($pathname, ($perm !== false) ? $perm : 0775, true);
@@ -318,7 +318,7 @@ class CaptureCache extends AbstractPattern
                 throw new Exception\RuntimeException("chmod('{$pathname}', 0{$oct}) failed", 0, $err);
             }
         } else {
-            // build-in mkdir function sets permission together with current umask
+            // built-in mkdir function sets permission together with current umask
             // which doesn't work well on multo threaded webservers
             // -> create directories one by one and set permissions
 

--- a/src/Pattern/PatternOptions.php
+++ b/src/Pattern/PatternOptions.php
@@ -446,7 +446,7 @@ class PatternOptions extends AbstractOptions
                 );
             } elseif ($filePermission & 0111) {
                 throw new Exception\InvalidArgumentException(
-                    "Invalid file permission: Files shoudn't be executable"
+                    "Invalid file permission: Files shouldn't be executable"
                 );
             }
         }

--- a/src/Storage/Adapter/Filesystem.php
+++ b/src/Storage/Adapter/Filesystem.php
@@ -1451,7 +1451,7 @@ class Filesystem extends AbstractAdapter implements
         ErrorHandler::start();
 
         if ($perm === false || $level == 1) {
-            // build-in mkdir function is enough
+            // built-in mkdir function is enough
 
             $umask = ($umask !== false) ? umask($umask) : false;
             $res   = mkdir($pathname, ($perm !== false) ? $perm : 0775, true);
@@ -1480,7 +1480,7 @@ class Filesystem extends AbstractAdapter implements
                 throw new Exception\RuntimeException("chmod('{$pathname}', 0{$oct}) failed", 0, $err);
             }
         } else {
-            // build-in mkdir function sets permission together with current umask
+            // built-in mkdir function sets permission together with current umask
             // which doesn't work well on multo threaded webservers
             // -> create directories one by one and set permissions
 

--- a/src/Storage/Adapter/FilesystemOptions.php
+++ b/src/Storage/Adapter/FilesystemOptions.php
@@ -322,7 +322,7 @@ class FilesystemOptions extends AdapterOptions
                 );
             } elseif ($filePermission & 0111) {
                 throw new Exception\InvalidArgumentException(
-                    "Invalid file permission: Cache files shoudn't be executable"
+                    "Invalid file permission: Cache files shouldn't be executable"
                 );
             }
         }

--- a/src/Storage/Adapter/RedisResourceManager.php
+++ b/src/Storage/Adapter/RedisResourceManager.php
@@ -299,7 +299,7 @@ class RedisResourceManager
         }
 
         if (! $success) {
-            throw new Exception\RuntimeException('Could not estabilish connection with Redis instance');
+            throw new Exception\RuntimeException('Could not establish connection with Redis instance');
         }
 
         $resource['initialized'] = true;

--- a/src/Storage/Capabilities.php
+++ b/src/Storage/Capabilities.php
@@ -122,7 +122,7 @@ class Capabilities
     protected $supportedDatatypes;
 
     /**
-     * Supported metdata
+     * Supported metadata
      *
      * If it's NULL the capability isn't set and the getter
      * returns the base capability or the default value.


### PR DESCRIPTION
Done with codespell's dictionary.

No impact is expected unless callers directly check exception messages.

Provide a narrative description of what you are trying to accomplish:

- [x] Are you fixing a bug? (fix harmless typos in exception messages)
  - [ ] Detail how the bug is invoked currently.
  - [ ] Detail the original, incorrect behavior.
  - [ ] Detail the new, expected behavior.
  - [ ] Base your feature on the `master` branch, and submit against that branch.
  - [ ] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.

- [x] Is this related to documentation?
  typographical fix