### PR TITLE
Fixes cache entry deletion directly after creation

### DIFF
--- a/src/Psr/SimpleCache/SimpleCacheDecorator.php
+++ b/src/Psr/SimpleCache/SimpleCacheDecorator.php
@@ -216,7 +216,10 @@ class SimpleCacheDecorator implements SimpleCacheInterface
 
         $options = $this->storage->getOptions();
         $previousTtl = $options->getTtl();
-        $options->setTtl($ttl);
+        
+        if (\null !== $ttl) {
+            $options->setTtl($ttl);
+        }
 
         try {
             $result = $this->storage->setItems($values);

--- a/src/Psr/SimpleCache/SimpleCacheDecorator.php
+++ b/src/Psr/SimpleCache/SimpleCacheDecorator.php
@@ -114,7 +114,7 @@ class SimpleCacheDecorator implements SimpleCacheInterface
         $options = $this->storage->getOptions();
         $previousTtl = $options->getTtl();
 
-        if (\null !== $ttl) {
+        if ($ttl !== null) {
             $options->setTtl($ttl);
         }
 
@@ -217,7 +217,7 @@ class SimpleCacheDecorator implements SimpleCacheInterface
         $options = $this->storage->getOptions();
         $previousTtl = $options->getTtl();
 
-        if (\null !== $ttl) {
+        if ($ttl !== null) {
             $options->setTtl($ttl);
         }
 

--- a/src/Psr/SimpleCache/SimpleCacheDecorator.php
+++ b/src/Psr/SimpleCache/SimpleCacheDecorator.php
@@ -113,8 +113,11 @@ class SimpleCacheDecorator implements SimpleCacheInterface
 
         $options = $this->storage->getOptions();
         $previousTtl = $options->getTtl();
-        $options->setTtl($ttl);
-
+        
+        if (\null !== $ttl) {
+            $options->setTtl($ttl);
+        }
+        
         try {
             $result = $this->storage->setItem($key, $value);
         } catch (Throwable $e) {

--- a/src/Psr/SimpleCache/SimpleCacheDecorator.php
+++ b/src/Psr/SimpleCache/SimpleCacheDecorator.php
@@ -113,11 +113,11 @@ class SimpleCacheDecorator implements SimpleCacheInterface
 
         $options = $this->storage->getOptions();
         $previousTtl = $options->getTtl();
-        
+
         if (\null !== $ttl) {
             $options->setTtl($ttl);
         }
-        
+
         try {
             $result = $this->storage->setItem($key, $value);
         } catch (Throwable $e) {
@@ -216,7 +216,7 @@ class SimpleCacheDecorator implements SimpleCacheInterface
 
         $options = $this->storage->getOptions();
         $previousTtl = $options->getTtl();
-        
+
         if (\null !== $ttl) {
             $options->setTtl($ttl);
         }

--- a/test/Psr/SimpleCache/TestAsset/TtlStorage.php
+++ b/test/Psr/SimpleCache/TestAsset/TtlStorage.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-cache for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-cache/blob/master/LICENSE.md New BSD License
+ */
+
+namespace ZendTest\Cache\Psr\SimpleCache\TestAsset;
+
+use Zend\Cache\Storage\Adapter;
+use Zend\Cache\Storage\Capabilities;
+
+class TtlStorage extends Adapter\AbstractAdapter
+{
+    /** @var array */
+    private $data = [];
+
+    /** @var array */
+    public $ttl = [];
+
+    protected function internalGetItem(& $normalizedKey, & $success = null, & $casToken = null)
+    {
+        $success = isset($this->data[$normalizedKey]);
+
+        return $success ? $this->data[$normalizedKey] : null;
+    }
+
+    protected function internalSetItem(& $normalizedKey, & $value)
+    {
+        $this->ttl[$normalizedKey] = $this->getOptions()->getTtl();
+
+        $this->data[$normalizedKey] = $value;
+        return true;
+    }
+
+    protected function internalRemoveItem(& $normalizedKey)
+    {
+        unset($this->data[$normalizedKey]);
+        return true;
+    }
+
+    public function setCapabilities(Capabilities $capabilities)
+    {
+        $this->capabilities = $capabilities;
+    }
+}


### PR DESCRIPTION
See
https://github.com/zendframework/zend-cache/issues/183

Only set TTL if there is a value which is not null!


