### PR TITLE
Issue #185 : replacing deprecated delete() calls with del()

### DIFF
--- a/.ci/redis.ini
+++ b/.ci/redis.ini
@@ -1,1 +1,0 @@
-extension=redis.so

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ matrix:
         - APCU_PECL_VERSION="apcu-4.0.8"
         - MEMCACHE_PECL_VERSION="memcache-2.2.7"
         - MEMCACHED_PECL_VERSION="memcached-2.2.0"
+        - REDIS_PECL_VERSION="redis-2.2.3"
         - TESTS_ZEND_CACHE_EXTMONGODB_ENABLED=false
         - TESTS_ZEND_CACHE_MEMCACHE_ENABLED=true
         - TESTS_ZEND_CACHE_XCACHE_ENABLED=true
@@ -56,6 +57,7 @@ matrix:
         - APCU_PECL_VERSION="apcu-4.0.10"
         - MEMCACHE_PECL_VERSION="memcache-3.0.7"
         - MEMCACHED_PECL_VERSION="memcached-2.2.0"
+        - REDIS_PECL_VERSION="redis-3.1.6"
         - TESTS_ZEND_CACHE_EXTMONGODB_ENABLED=false
         - TESTS_ZEND_CACHE_MEMCACHE_ENABLED=true
         - TESTS_ZEND_CACHE_XCACHE_ENABLED=true
@@ -65,6 +67,7 @@ matrix:
         - APCU_PECL_VERSION="apcu-4.0.11"
         - MEMCACHE_PECL_VERSION="memcache-3.0.8"
         - MEMCACHED_PECL_VERSION="memcached-2.2.0"
+        - REDIS_PECL_VERSION="redis-4.3.0"
         - TESTS_ZEND_CACHE_EXTMONGODB_ENABLED=false
         - TESTS_ZEND_CACHE_MEMCACHE_ENABLED=true
         - TESTS_ZEND_CACHE_XCACHE_ENABLED=true
@@ -73,6 +76,7 @@ matrix:
         - DEPS=lowest
         - APCU_PECL_VERSION="apcu-5.1.2"
         - APCU_BC_PECL_VERSION="apcu_bc-1.0.0"
+        - REDIS_PECL_VERSION="redis-4.0.0"
         - TESTS_ZEND_CACHE_MONGODB_USE_POLYFILL=true
         - TESTS_ZEND_CACHE_EXTMONGODB_ENABLED=false
     - php: 7
@@ -81,6 +85,7 @@ matrix:
         - LEGACY_DEPS="phpbench/phpbench phpunit/phpunit"
         - APCU_PECL_VERSION="apcu-5.1.8"
         - APCU_BC_PECL_VERSION="apcu_bc-1.0.2"
+        - REDIS_PECL_VERSION="redis-5.0.0"
         - TESTS_ZEND_CACHE_MONGODB_USE_POLYFILL=true
         - TESTS_ZEND_CACHE_EXTMONGODB_ENABLED=false
     - php: 7
@@ -88,6 +93,7 @@ matrix:
         - DEPS=latest
         - APCU_PECL_VERSION="apcu"
         - APCU_BC_PECL_VERSION="apcu_bc-1.0.3"
+        - REDIS_PECL_VERSION="redis-5.0.2"
         - TESTS_ZEND_CACHE_MONGODB_USE_POLYFILL=true
         - TESTS_ZEND_CACHE_EXTMONGODB_ENABLED=false
     - php: 7.1
@@ -95,6 +101,7 @@ matrix:
         - DEPS=lowest
         - APCU_PECL_VERSION="apcu-5.1.7"
         - APCU_BC_PECL_VERSION="apcu_bc-1.0.2"
+        - REDIS_PECL_VERSION="redis-4.0.0"
         - TESTS_ZEND_CACHE_MONGODB_USE_POLYFILL=true
     - php: 7.1
       env:
@@ -104,30 +111,35 @@ matrix:
         - TEST_COVERAGE=true
         - APCU_PECL_VERSION="apcu-5.1.8"
         - APCU_BC_PECL_VERSION="apcu_bc-1.0.2"
+        - REDIS_PECL_VERSION="redis-5.0.0"
         - TESTS_ZEND_CACHE_MONGODB_USE_POLYFILL=true
     - php: 7.1
       env:
         - DEPS=latest
         - APCU_PECL_VERSION="apcu"
         - APCU_BC_PECL_VERSION="apcu_bc-1.0.3"
+        - REDIS_PECL_VERSION="redis-5.0.2"
         - TESTS_ZEND_CACHE_MONGODB_USE_POLYFILL=true
     - php: 7.2
       env:
         - DEPS=lowest
         - APCU_PECL_VERSION="apcu-5.1.10"
         - APCU_BC_PECL_VERSION="apcu_bc-1.0.2"
+        - REDIS_PECL_VERSION="redis-4.0.0"
         - TESTS_ZEND_CACHE_MONGODB_USE_POLYFILL=true
     - php: 7.2
       env:
         - DEPS=locked
         - APCU_PECL_VERSION="apcu-5.1.10"
         - APCU_BC_PECL_VERSION="apcu_bc-1.0.2"
+        - REDIS_PECL_VERSION="redis-5.0.0"
         - TESTS_ZEND_CACHE_MONGODB_USE_POLYFILL=true
     - php: 7.2
       env:
         - DEPS=latest
         - APCU_PECL_VERSION="apcu"
         - APCU_BC_PECL_VERSION="apcu_bc-1.0.3"
+        - REDIS_PECL_VERSION="redis-5.0.2"
         - TESTS_ZEND_CACHE_MONGODB_USE_POLYFILL=true
 
 before_install:
@@ -162,7 +174,7 @@ install:
     fi ;
 
   - if [[ $TESTS_ZEND_CACHE_REDIS_ENABLED == 'true' ]]; then
-        phpenv config-add .ci/redis.ini ;
+        echo "no" | pecl install -f $REDIS_PECL_VERSION ;
     fi ;
 
   - if [[ $TESTS_ZEND_CACHE_MEMCACHE_ENABLED == 'true' ]]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#186](https://github.com/zendframework/zend-cache/pull/186) Replaced deprecated `Redis::delete()` calls with `del()`. 
 
 ## 2.8.3 - TBD
 

--- a/src/Storage/Adapter/Redis.php
+++ b/src/Storage/Adapter/Redis.php
@@ -356,7 +356,7 @@ class Redis extends AbstractAdapter implements
     {
         $redis = $this->getRedisResource();
         try {
-            return (bool) $redis->delete($this->namespacePrefix . $normalizedKey);
+            return (bool) $redis->del($this->namespacePrefix . $normalizedKey);
         } catch (RedisResourceException $e) {
             throw new Exception\RuntimeException($redis->getLastError(), $e->getCode(), $e);
         }
@@ -434,7 +434,7 @@ class Redis extends AbstractAdapter implements
         $options = $this->getOptions();
         $prefix  = $namespace . $options->getNamespaceSeparator();
 
-        $redis->delete($redis->keys($prefix . '*'));
+        $redis->del($redis->keys($prefix . '*'));
 
         return true;
     }
@@ -460,7 +460,7 @@ class Redis extends AbstractAdapter implements
         $namespace = $options->getNamespace();
         $prefix    = ($namespace === '') ? '' : $namespace . $options->getNamespaceSeparator() . $prefix;
 
-        $redis->delete($redis->keys($prefix.'*'));
+        $redis->del($redis->keys($prefix.'*'));
 
         return true;
     }


### PR DESCRIPTION
Fixing Issue #185 
Since redis extension 5.0.0, Deprecation errors are thrown on every Redis::delete() call.
Replacing the delete() calls with del() calls fixes these messages.