### PR TITLE
Fix unused private $tz, add missing $utc private properties

### DIFF
--- a/src/Psr/CacheItemPool/CacheItem.php
+++ b/src/Psr/CacheItemPool/CacheItem.php
@@ -48,7 +48,7 @@ final class CacheItem implements CacheItemInterface
     /**
      * @var DateTimeZone
      */
-    private $tz;
+    private $utc;
 
     /**
      * Constructor.


### PR DESCRIPTION
In code constructor, $this->utc referenced a non-existing property; at the same time, a DateTimeZone private property $tz was declared but not used.

It seems property got renamed somewhere in time in code usage, but not in property declaration.

Provide a narrative description of what you are trying to accomplish:

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [ ] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.

- [ ] Are you creating a new feature?
  - [ ] Why is the new feature needed? What purpose does it serve?
  - [ ] How will users use the new feature?
  - [ ] Base your feature on the `develop` branch, and submit against that branch.
  - [ ] Add only one feature per pull request; split multiple features over multiple pull requests
  - [ ] Add tests for the new feature.
  - [ ] Add documentation for the new feature.
  - [ ] Add a `CHANGELOG.md` entry for the new feature.

- [ ] Is this related to quality assurance?
  <!-- Detail why the changes are necessary -->

- [ ] Is this related to documentation?
  <!-- Is it a typographical and/or grammatical fix? -->
  <!-- Is it new documentation? -->
